### PR TITLE
Add UCxn annotations

### DIFF
--- a/zh_hk-ud-test.conllu
+++ b/zh_hk-ud-test.conllu
@@ -3,16 +3,16 @@
 # translit = nǐzàizhǎoxiēshénme?
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Gloss=2SG|Translit=nǐ|LTranslit=nǐ
 2	在	在	ADV	_	_	3	advmod	_	SpaceAfter=No|Gloss=PROG|Translit=zài|LTranslit=zài
-3	找	找	VERB	_	_	0	root	_	SpaceAfter=No|Gloss=find|Translit=zhǎo|LTranslit=zhǎo
+3	找	找	VERB	_	_	0	root	_	SpaceAfter=No|Gloss=find|Translit=zhǎo|LTranslit=zhǎo|Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	些	些	NOUN	_	NounType=Clf	5	clf	_	SpaceAfter=No|Gloss=CLF.PL|Translit=xiē|LTranslit=xiē
-5	什麼	什麼	PRON	_	_	3	obj	_	SpaceAfter=No|Gloss=what|Translit=shénme|LTranslit=shénme
+5	什麼	什麼	PRON	_	_	3	obj	_	SpaceAfter=No|Gloss=what|Translit=shénme|LTranslit=shénme|CxnElt=3:Interrogative-WHInfo-Direct.WHWord
 6	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 2
 # text = 收拾好哥哥的物品再拿去他的新家。
 # translit = shōushihǎogēgēdewùpǐnzàináqùtādexīnjiā.
-1	收拾	收拾	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shōushi|LTranslit=shōushi
-2	好	好	ADJ	_	_	1	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
+1	收拾	收拾	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shōushi|LTranslit=shōushi|Cxn=Resultative|CxnElt=1:Resultative.Event
+2	好	好	ADJ	_	_	1	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo|CxnElt=1:Resultative.ResultState
 3	哥哥	哥哥	NOUN	_	_	5	nmod	_	SpaceAfter=No|Translit=gēgē|LTranslit=gēgē
 4	的	的	PART	_	_	3	case	_	SpaceAfter=No|Translit=de|LTranslit=de
 5	物品	物品	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=wùpǐn|LTranslit=wùpǐn
@@ -29,12 +29,12 @@
 # text = 該取走的都取走了！
 # translit = gāiqǔzǒudedōuqǔzǒule!
 1	該	該	AUX	_	_	2	aux	_	SpaceAfter=No|Translit=gāi|LTranslit=gāi
-2	取	取	VERB	_	_	6	obj:periph	_	SpaceAfter=No|Translit=qǔ|LTranslit=qǔ
-3	走	走	VERB	_	_	2	compound:vv	_	SpaceAfter=No|Translit=zǒu|LTranslit=zǒu
+2	取	取	VERB	_	_	6	obj:periph	_	SpaceAfter=No|Translit=qǔ|LTranslit=qǔ|Cxn=Resultative|CxnElt=2:Resultative.Event
+3	走	走	VERB	_	_	2	compound:vv	_	SpaceAfter=No|Translit=zǒu|LTranslit=zǒu|CxnElt=2:Resultative.ResultState
 4	的	的	PART	_	_	2	mark:rel	_	SpaceAfter=No|Translit=de|LTranslit=de
 5	都	都	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=dōu|LTranslit=dōu
-6	取	取	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǔ|LTranslit=qǔ
-7	走	走	VERB	_	_	6	compound:vv	_	SpaceAfter=No|Translit=zǒu|LTranslit=zǒu
+6	取	取	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǔ|LTranslit=qǔ|Cxn=Resultative|CxnElt=6:Resultative.Event
+7	走	走	VERB	_	_	6	compound:vv	_	SpaceAfter=No|Translit=zǒu|LTranslit=zǒu|CxnElt=6:Resultative.ResultState
 8	了	了	PART	_	_	6	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 9	！	！	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
@@ -53,8 +53,8 @@
 1	也	也	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=yě|LTranslit=yě
 2	總	總	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=zǒng|LTranslit=zǒng
 3	要	要	AUX	_	_	4	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
-4	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-5	人	人	NOUN	_	_	4	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén
+4	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+5	人	人	NOUN	_	_	4	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén|CxnElt=4:Existential-HavePred.Pivot
 6	收拾	收拾	VERB	_	_	5	acl	_	SpaceAfter=No|Translit=shōushi|LTranslit=shōushi
 7	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
@@ -64,7 +64,7 @@
 1	豪仔	豪仔	PROPN	_	_	4	nsubj	_	SpaceAfter=No|Translit=háozǐ|LTranslit=háozǐ
 2	今晚	今晚	NOUN	_	_	4	obl:tmod	_	SpaceAfter=No|Translit=jīnwǎn|LTranslit=jīnwǎn
 3	點	點	NOUN	_	NounType=Clf	4	reparandum	_	SpaceAfter=No|Translit=diǎn|LTranslit=diǎn
-4	來	來	VERB	_	_	0	root	_	SpaceAfter=No|Translit=lái|LTranslit=lái
+4	來	來	VERB	_	_	0	root	_	SpaceAfter=No|Translit=lái|LTranslit=lái|Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause
 5	吃飯	吃飯	VERB	_	_	4	conj	_	SpaceAfter=No|Translit=chīfàn|LTranslit=chīfàn
 6	嗎	嗎	PART	_	_	4	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 7	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -94,7 +94,7 @@
 # translit = zhèxiēdōuméiyòngleba?
 1	這些	這些	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=zhèxiē|LTranslit=zhèxiē
 2	都	都	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=dōu|LTranslit=dōu
-3	沒用	沒用	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=méiyòng|LTranslit=méiyòng
+3	沒用	沒用	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=méiyòng|LTranslit=méiyòng|Cxn=Interrogative-Reduced|CxnElt=3:Interrogative-Reduced.Clause
 4	了	了	PART	_	_	3	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 5	吧	吧	PART	_	_	3	discourse:sp	_	SpaceAfter=No|Translit=ba|LTranslit=ba
 6	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -117,7 +117,7 @@
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 3	我	我	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 4	可以	可以	AUX	_	_	5	aux	_	SpaceAfter=No|Translit=kěyǐ|LTranslit=kěyǐ
-5	去	去	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qù|LTranslit=qù
+5	去	去	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qù|LTranslit=qù|Cxn=Interrogative-Polar-Direct|CxnElt=5:Interrogative-Polar-Direct.Clause
 6	看	看	VERB	_	_	5	conj	_	SpaceAfter=No|Translit=kàn|LTranslit=kàn
 7	新	新	ADJ	_	_	10	amod	_	SpaceAfter=No|Translit=xīn|LTranslit=xīn
 8	一	一	NUM	_	_	10	nummod	_	SpaceAfter=No|Translit=yī|LTranslit=yī
@@ -137,8 +137,8 @@
 6	，	，	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 7	跟	跟	ADP	_	_	8	case	_	SpaceAfter=No|Translit=gēn|LTranslit=gēn
 8	你	你	PRON	_	_	9	obl	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-9	對	對	VERB	_	_	4	conj	_	SpaceAfter=No|Translit=duì|LTranslit=duì
-10	好	好	ADJ	_	_	9	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
+9	對	對	VERB	_	_	4	conj	_	SpaceAfter=No|Translit=duì|LTranslit=duì|Cxn=Resultative|CxnElt=9:Resultative.Event
+10	好	好	ADJ	_	_	9	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo|CxnElt=9:Resultative.ResultState
 11	功課	功課	NOUN	_	_	9	obj	_	SpaceAfter=No|Translit=gōngkè|LTranslit=gōngkè
 12	才	才	ADV	_	_	13	advmod	_	SpaceAfter=No|Translit=cái|LTranslit=cái
 13	看	看	VERB	_	_	0	root	_	SpaceAfter=No|Translit=kàn|LTranslit=kàn
@@ -151,8 +151,8 @@
 1	爺爺	爺爺	NOUN	_	_	4	vocative	_	SpaceAfter=No|Translit=yeye|LTranslit=yeye
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 3	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
-4	做	做	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò
-5	好	好	ADJ	_	_	4	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
+4	做	做	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò|Cxn=Resultative|CxnElt=4:Resultative.Event
+5	好	好	ADJ	_	_	4	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo|CxnElt=4:Resultative.ResultState
 6	功課	功課	NOUN	_	_	4	obj	_	SpaceAfter=No|Translit=gōngkè|LTranslit=gōngkè
 7	了	了	PART	_	_	4	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 8	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
@@ -160,7 +160,7 @@
 # sent_id = 13
 # text = 默書呢？
 # translit = mòshūne?
-1	默書	默書	VERB	_	_	0	root	_	SpaceAfter=No|Translit=mòshū|LTranslit=mòshū
+1	默書	默書	VERB	_	_	0	root	_	SpaceAfter=No|Translit=mòshū|LTranslit=mòshū|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=ne|LTranslit=ne
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -174,7 +174,7 @@
 # sent_id = 15
 # text = 沒有？
 # translit = méiyǒu?
-1	沒有	有	VERB	_	Polarity=Neg	0	root	_	SpaceAfter=No|Translit=méiyǒu|LTranslit=yǒu
+1	沒有	有	VERB	_	Polarity=Neg	0	root	_	SpaceAfter=No|Translit=méiyǒu|LTranslit=yǒu|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 16
@@ -326,8 +326,8 @@
 # sent_id = 32
 # text = 弄好沒有嗎？
 # translit = nònghǎoméiyǒuma?
-1	弄	弄	VERB	_	_	0	root	_	SpaceAfter=No|Translit=nòng|LTranslit=nòng
-2	好	好	VERB	_	_	1	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
+1	弄	弄	VERB	_	_	0	root	_	SpaceAfter=No|Translit=nòng|LTranslit=nòng|Cxn=Interrogative-Polar-Direct,Resultative|CxnElt=1:Interrogative-Polar-Direct.Clause,1:Resultative.Event
+2	好	好	VERB	_	_	1	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo|CxnElt=1:Resultative.ResultState
 3	沒有	有	AUX	_	Polarity=Neg	1	conj	_	SpaceAfter=No|Translit=méiyǒu|LTranslit=yǒu
 4	嗎	嗎	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -445,7 +445,7 @@
 # sent_id = 47
 # text = 多少？
 # translit = duōshǎo?
-1	多少	多少	PRON	_	_	0	root	_	SpaceAfter=No|Translit=duōshǎo|LTranslit=duōshǎo
+1	多少	多少	PRON	_	_	0	root	_	SpaceAfter=No|Translit=duōshǎo|LTranslit=duōshǎo|Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 48
@@ -498,7 +498,7 @@
 # sent_id = 53
 # text = 這些呢？
 # translit = zhèxiēne?
-1	這些	這些	PRON	_	_	0	root	_	SpaceAfter=No|Translit=zhèxiē|LTranslit=zhèxiē
+1	這些	這些	PRON	_	_	0	root	_	SpaceAfter=No|Translit=zhèxiē|LTranslit=zhèxiē|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=ne|LTranslit=ne
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -555,9 +555,9 @@
 # sent_id = 59
 # text = 有什麼事？
 # translit = yǒushénmeshì?
-1	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-2	什麼	什麼	DET	_	_	3	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
-3	事	事	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+1	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+2	什麼	什麼	DET	_	_	3	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=3:Interrogative-WHInfo-Direct.WHWord
+3	事	事	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Existential-HavePred.Pivot,3:Interrogative-WHInfo-Direct.Clause
 4	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 60
@@ -633,7 +633,7 @@
 # text = 你洗手了嗎？
 # translit = nǐxǐshǒulema?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-2	洗	洗	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xǐ|LTranslit=xǐ
+2	洗	洗	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xǐ|LTranslit=xǐ|Cxn=Interrogative-Polar-Direct|CxnElt=2:Interrogative-Polar-Direct.Clause
 3	手	手	NOUN	_	_	2	obj	_	SpaceAfter=No|Translit=shǒu|LTranslit=shǒu
 4	了	了	PART	_	_	2	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 5	嗎	嗎	PART	_	_	2	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
@@ -642,8 +642,8 @@
 # sent_id = 68
 # text = 洗乾淨了！
 # translit = xǐ乾jìngle!
-1	洗	洗	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xǐ|LTranslit=xǐ
-2	乾淨	乾淨	ADJ	_	_	1	compound:vv	_	SpaceAfter=No|Translit=乾jìng|LTranslit=乾jìng
+1	洗	洗	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xǐ|LTranslit=xǐ|Cxn=Resultative|CxnElt=1:Resultative.Event
+2	乾淨	乾淨	ADJ	_	_	1	compound:vv	_	SpaceAfter=No|Translit=乾jìng|LTranslit=乾jìng|CxnElt=1:Resultative.ResultState
 3	了	了	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
@@ -709,8 +709,8 @@
 # sent_id = 76
 # text = 換好吧？
 # translit = huànhǎoba?
-1	換	換	VERB	_	_	0	root	_	SpaceAfter=No|Translit=huàn|LTranslit=huàn
-2	好	好	ADJ	_	_	1	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
+1	換	換	VERB	_	_	0	root	_	SpaceAfter=No|Translit=huàn|LTranslit=huàn|Cxn=Interrogative-Reduced,Resultative|CxnElt=1:Interrogative-Reduced.Clause,1:Resultative.Event
+2	好	好	ADJ	_	_	1	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo|CxnElt=1:Resultative.ResultState
 3	吧	吧	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=ba|LTranslit=ba
 4	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -732,7 +732,7 @@
 6	很	很	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=hěn|LTranslit=hěn
 7	喜歡	喜歡	VERB	_	_	9	acl	_	SpaceAfter=No|Translit=xǐhuan|LTranslit=xǐhuan
 8	的	的	PART	_	_	7	mark:rel	_	SpaceAfter=No|Translit=de|LTranslit=de
-9	悟空	悟空	PROPN	_	_	0	root	_	SpaceAfter=No|Translit=wùkōng|LTranslit=wùkōng
+9	悟空	悟空	PROPN	_	_	0	root	_	SpaceAfter=No|Translit=wùkōng|LTranslit=wùkōng|Cxn=Interrogative-Polar-Direct|CxnElt=9:Interrogative-Polar-Direct.Clause
 10	嗎	嗎	PART	_	_	9	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 11	？	？	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -760,8 +760,8 @@
 # sent_id = 81
 # text = 玩夠了！
 # translit = wángòule!
-1	玩	玩	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wán|LTranslit=wán
-2	夠	夠	VERB	_	_	1	compound:vv	_	SpaceAfter=No|Translit=gòu|LTranslit=gòu
+1	玩	玩	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wán|LTranslit=wán|Cxn=Resultative|CxnElt=1:Resultative.Event
+2	夠	夠	VERB	_	_	1	compound:vv	_	SpaceAfter=No|Translit=gòu|LTranslit=gòu|CxnElt=1:Resultative.ResultState
 3	了	了	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
@@ -954,8 +954,8 @@
 # sent_id = 101
 # text = 有餸。
 # translit = yǒu餸.
-1	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-2	餸	餸	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=餸|LTranslit=餸
+1	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+2	餸	餸	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=餸|LTranslit=餸|CxnElt=1:Existential-HavePred.Pivot
 3	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 102
@@ -976,8 +976,8 @@
 # sent_id = 104
 # text = 用耐了便壞。
 # translit = yòngnàilebiànhuài.
-1	用	用	VERB	_	_	5	advcl	_	SpaceAfter=No|Translit=yòng|LTranslit=yòng
-2	耐	耐	ADJ	_	_	1	compound:vv	_	SpaceAfter=No|Translit=nài|LTranslit=nài
+1	用	用	VERB	_	_	5	advcl	_	SpaceAfter=No|Translit=yòng|LTranslit=yòng|Cxn=Resultative|CxnElt=1:Resultative.Event
+2	耐	耐	ADJ	_	_	1	compound:vv	_	SpaceAfter=No|Translit=nài|LTranslit=nài|CxnElt=1:Resultative.ResultState
 3	了	了	AUX	_	_	2	aux	_	SpaceAfter=No|Translit=le|LTranslit=le
 4	便	便	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=biàn|LTranslit=biàn
 5	壞	壞	VERB	_	_	0	root	_	SpaceAfter=No|Translit=huài|LTranslit=huài
@@ -1097,8 +1097,8 @@
 # text = 快播完了！
 # translit = kuàibōwánle!
 1	快	快	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=kuài|LTranslit=kuài
-2	播	播	VERB	_	_	0	root	_	SpaceAfter=No|Translit=bō|LTranslit=bō
-3	完	完	VERB	_	_	2	compound:vv	_	SpaceAfter=No|Translit=wán|LTranslit=wán
+2	播	播	VERB	_	_	0	root	_	SpaceAfter=No|Translit=bō|LTranslit=bō|Cxn=Resultative|CxnElt=2:Resultative.Event
+3	完	完	VERB	_	_	2	compound:vv	_	SpaceAfter=No|Translit=wán|LTranslit=wán|CxnElt=2:Resultative.ResultState
 4	了	了	PART	_	_	2	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 5	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
@@ -1268,14 +1268,14 @@
 # sent_id = 132
 # text = 見到別人有十個一元左右，就排在他後面。
 # translit = jiàndàobiérényǒushígèyīyuánzuǒyòu,jiùpáizàitāhòumiàn.
-1	見	見	VERB	_	_	12	advcl	_	SpaceAfter=No|Translit=jiàn|LTranslit=jiàn
-2	到	到	VERB	_	_	1	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+1	見	見	VERB	_	_	12	advcl	_	SpaceAfter=No|Translit=jiàn|LTranslit=jiàn|Cxn=Resultative|CxnElt=1:Resultative.Event
+2	到	到	VERB	_	_	1	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=1:Resultative.ResultState
 3	別人	別人	PRON	_	_	1	obj	_	SpaceAfter=No|Translit=biérén|LTranslit=biérén
-4	有	有	VERB	_	_	1	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
+4	有	有	VERB	_	_	1	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
 5	十	十	NUM	_	_	8	nummod	_	SpaceAfter=No|Translit=shí|LTranslit=shí
 6	個	個	NOUN	_	NounType=Clf	5	clf	_	SpaceAfter=No|Translit=gè|LTranslit=gè
 7	一	一	NUM	_	_	8	nummod	_	SpaceAfter=No|Translit=yī|LTranslit=yī
-8	元	元	NOUN	_	NounType=Clf	4	obj	_	SpaceAfter=No|Translit=yuán|LTranslit=yuán
+8	元	元	NOUN	_	NounType=Clf	4	obj	_	SpaceAfter=No|Translit=yuán|LTranslit=yuán|CxnElt=4:Existential-HavePred.Pivot
 9	左右	左右	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=zuǒyòu|LTranslit=zuǒyòu
 10	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 11	就	就	ADV	_	_	12	advmod	_	SpaceAfter=No|Translit=jiù|LTranslit=jiù
@@ -1290,8 +1290,8 @@
 # translit = děngtāniǔguāngshíyuányěbùzhōngshǎnkǎshí,wǒmenbiànxíngdòng.
 1	等	等	VERB	_	_	15	advcl	_	SpaceAfter=No|Translit=děng|LTranslit=děng
 2	他	他	PRON	_	_	1	obj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
-3	扭	扭	VERB	_	_	9	advcl	_	SpaceAfter=No|Translit=niǔ|LTranslit=niǔ
-4	光	光	VERB	_	_	3	compound:vv	_	SpaceAfter=No|Translit=guāng|LTranslit=guāng
+3	扭	扭	VERB	_	_	9	advcl	_	SpaceAfter=No|Translit=niǔ|LTranslit=niǔ|Cxn=Resultative|CxnElt=3:Resultative.Event
+4	光	光	VERB	_	_	3	compound:vv	_	SpaceAfter=No|Translit=guāng|LTranslit=guāng|CxnElt=3:Resultative.ResultState
 5	十	十	NUM	_	_	6	nummod	_	SpaceAfter=No|Translit=shí|LTranslit=shí
 6	元	元	NOUN	_	NounType=Clf	3	obj	_	SpaceAfter=No|Translit=yuán|LTranslit=yuán
 7	也	也	ADV	_	_	9	advmod	_	SpaceAfter=No|Translit=yě|LTranslit=yě
@@ -1339,8 +1339,8 @@
 # text = 不要弄壞我的機。
 # translit = bùyàonònghuàiwǒdejī.
 1	不要	要	AUX	_	Polarity=Neg	2	aux	_	SpaceAfter=No|Translit=bùyào|LTranslit=yào
-2	弄	弄	VERB	_	_	0	root	_	SpaceAfter=No|Translit=nòng|LTranslit=nòng
-3	壞	壞	VERB	_	_	2	compound:vv	_	SpaceAfter=No|Translit=huài|LTranslit=huài
+2	弄	弄	VERB	_	_	0	root	_	SpaceAfter=No|Translit=nòng|LTranslit=nòng|Cxn=Resultative|CxnElt=2:Resultative.Event
+3	壞	壞	VERB	_	_	2	compound:vv	_	SpaceAfter=No|Translit=huài|LTranslit=huài|CxnElt=2:Resultative.ResultState
 4	我	我	PRON	_	_	6	nmod	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 5	的	的	PART	_	_	4	case	_	SpaceAfter=No|Translit=de|LTranslit=de
 6	機	機	NOUN	_	_	2	obj	_	SpaceAfter=No|Translit=jī|LTranslit=jī
@@ -1391,8 +1391,8 @@
 2	要	要	AUX	_	_	5	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
 3	被	被	ADP	_	_	4	case	_	SpaceAfter=No|Translit=bèi|LTranslit=bèi
 4	人	人	NOUN	_	_	5	obl:agent	_	SpaceAfter=No|Translit=rén|LTranslit=rén
-5	抓	抓	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhuā|LTranslit=zhuā
-6	到	到	VERB	_	_	5	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+5	抓	抓	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhuā|LTranslit=zhuā|Cxn=Resultative|CxnElt=5:Resultative.Event
+6	到	到	VERB	_	_	5	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=5:Resultative.ResultState
 7	了	了	PART	_	_	5	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 8	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
@@ -1406,8 +1406,8 @@
 # text = 你在哪？
 # translit = nǐzàinǎ?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-2	在	在	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zài|LTranslit=zài
-3	哪	哪	PRON	_	_	2	obj	_	SpaceAfter=No|Translit=nǎ|LTranslit=nǎ
+2	在	在	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zài|LTranslit=zài|Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
+3	哪	哪	PRON	_	_	2	obj	_	SpaceAfter=No|Translit=nǎ|LTranslit=nǎ|CxnElt=2:Interrogative-WHInfo-Direct.WHWord
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 146
@@ -1420,8 +1420,8 @@
 # text = 你在哪？
 # translit = nǐzàinǎ?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-2	在	在	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zài|LTranslit=zài
-3	哪	哪	PRON	_	_	2	obj	_	SpaceAfter=No|Translit=nǎ|LTranslit=nǎ
+2	在	在	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zài|LTranslit=zài|Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
+3	哪	哪	PRON	_	_	2	obj	_	SpaceAfter=No|Translit=nǎ|LTranslit=nǎ|CxnElt=2:Interrogative-WHInfo-Direct.WHWord
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 148
@@ -1456,8 +1456,8 @@
 # text = 你怎麼知道？
 # translit = nǐzěnmezhīdào?
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-2	怎麼	怎麼	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=zěnme|LTranslit=zěnme
-3	知道	知道	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhīdào|LTranslit=zhīdào
+2	怎麼	怎麼	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=zěnme|LTranslit=zěnme|CxnElt=3:Interrogative-WHInfo-Direct.WHWord
+3	知道	知道	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhīdào|LTranslit=zhīdào|Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 152
@@ -1473,7 +1473,7 @@
 # sent_id = 153
 # text = 是嘛？
 # translit = shìma?
-1	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+1	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
 2	嘛	嘛	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -1497,15 +1497,15 @@
 1	那時	那時	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=nàshí|LTranslit=nàshí
 2	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 3	在	在	VERB	_	_	4	reparandum	_	SpaceAfter=No|Translit=zài|LTranslit=zài
-4	去	去	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qù|LTranslit=qù
+4	去	去	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qù|LTranslit=qù|Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	了	了	AUX	_	_	4	aux	_	SpaceAfter=No|Translit=le|LTranslit=le
-6	哪裡	哪裡	PRON	_	_	4	obj	_	SpaceAfter=No|Translit=nǎli|LTranslit=nǎli
+6	哪裡	哪裡	PRON	_	_	4	obj	_	SpaceAfter=No|Translit=nǎli|LTranslit=nǎli|CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 7	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 156
 # text = 你？
 # translit = nǐ?
-1	你	你	PRON	_	_	0	root	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
+1	你	你	PRON	_	_	0	root	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 157
@@ -1520,8 +1520,8 @@
 # sent_id = 158
 # text = 怎可能？
 # translit = zěnkěnéng?
-1	怎	怎	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zěn|LTranslit=zěn
-2	可能	可能	AUX	_	_	0	root	_	SpaceAfter=No|Translit=kěnéng|LTranslit=kěnéng
+1	怎	怎	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zěn|LTranslit=zěn|CxnElt=2:Interrogative-WHInfo-Direct.WHWord
+2	可能	可能	AUX	_	_	0	root	_	SpaceAfter=No|Translit=kěnéng|LTranslit=kěnéng|Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
 3	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 159
@@ -1573,7 +1573,7 @@
 # text = 你心虛啊？
 # translit = nǐxīnxū'a?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-2	心虛	心虛	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xīnxū|LTranslit=xīnxū
+2	心虛	心虛	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xīnxū|LTranslit=xīnxū|Cxn=Interrogative-Reduced|CxnElt=2:Interrogative-Reduced.Clause
 3	啊	啊	PART	_	_	2	discourse:sp	_	SpaceAfter=No|Translit='a|LTranslit='a
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -1622,7 +1622,7 @@
 # text = 你知道嗎？
 # translit = nǐzhīdàoma?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-2	知道	知道	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhīdào|LTranslit=zhīdào
+2	知道	知道	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhīdào|LTranslit=zhīdào|Cxn=Interrogative-Polar-Direct|CxnElt=2:Interrogative-Polar-Direct.Clause
 3	嗎	嗎	PART	_	_	2	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -1688,9 +1688,9 @@
 # sent_id = 174
 # text = 哪有人喜歡黎明？
 # translit = nǎyǒurénxǐhuanlímíng?
-1	哪	哪	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=nǎ|LTranslit=nǎ
-2	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-3	人	人	NOUN	_	_	2	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén
+1	哪	哪	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=nǎ|LTranslit=nǎ|CxnElt=2:Interrogative-WHInfo-Direct.WHWord
+2	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred,Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
+3	人	人	NOUN	_	_	2	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén|CxnElt=2:Existential-HavePred.Pivot
 4	喜歡	喜歡	VERB	_	_	3	acl	_	SpaceAfter=No|Translit=xǐhuan|LTranslit=xǐhuan
 5	黎明	黎明	PROPN	_	_	4	obj	_	SpaceAfter=No|Translit=límíng|LTranslit=límíng
 6	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -1720,7 +1720,7 @@
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 2	可以	可以	AUX	_	_	4	aux	_	SpaceAfter=No|Translit=kěyǐ|LTranslit=kěyǐ
 3	……	……	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
-4	做	做	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò
+4	做	做	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò|Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause
 5	我	我	PRON	_	_	8	nmod	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 6	的	的	PART	_	_	5	case	_	SpaceAfter=No|Translit=de|LTranslit=de
 7	……	……	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
@@ -1743,8 +1743,8 @@
 # sent_id = 179
 # text = 什麼眾數、平均數、中位數？
 # translit = shénmezhòngshù,píngjūnshù,zhōngwèishù?
-1	什麼	什麼	DET	_	_	2	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
-2	眾數	眾數	NOUN	_	_	0	root	_	SpaceAfter=No|Translit=zhòngshù|LTranslit=zhòngshù
+1	什麼	什麼	DET	_	_	2	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=2:Interrogative-WHInfo-Direct.WHWord
+2	眾數	眾數	NOUN	_	_	0	root	_	SpaceAfter=No|Translit=zhòngshù|LTranslit=zhòngshù|Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
 3	、	、	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 4	平均數	平均數	NOUN	_	_	2	conj	_	SpaceAfter=No|Translit=píngjūnshù|LTranslit=píngjūnshù
 5	、	、	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
@@ -1754,8 +1754,8 @@
 # sent_id = 180
 # text = 怎麼分辨？
 # translit = zěnmefēnbiàn?
-1	怎麼	怎麼	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zěnme|LTranslit=zěnme
-2	分辨	分辨	VERB	_	_	0	root	_	SpaceAfter=No|Translit=fēnbiàn|LTranslit=fēnbiàn
+1	怎麼	怎麼	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zěnme|LTranslit=zěnme|CxnElt=2:Interrogative-WHInfo-Direct.WHWord
+2	分辨	分辨	VERB	_	_	0	root	_	SpaceAfter=No|Translit=fēnbiàn|LTranslit=fēnbiàn|Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
 3	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 181
@@ -1771,7 +1771,7 @@
 # translit = zuìgāopínlǜnàzǔma?
 1	最	最	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zuì|LTranslit=zuì
 2	高	高	ADJ	_	_	3	amod	_	SpaceAfter=No|Translit=gāo|LTranslit=gāo
-3	頻率	頻率	NOUN	_	_	0	root	_	SpaceAfter=No|Translit=pínlǜ|LTranslit=pínlǜ
+3	頻率	頻率	NOUN	_	_	0	root	_	SpaceAfter=No|Translit=pínlǜ|LTranslit=pínlǜ|Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	那	那	DET	_	_	5	det	_	SpaceAfter=No|Translit=nà|LTranslit=nà
 5	組	組	NOUN	_	NounType=Clf	3	appos	_	SpaceAfter=No|Translit=zǔ|LTranslit=zǔ
 6	嗎	嗎	PART	_	_	3	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
@@ -1786,7 +1786,7 @@
 # sent_id = 184
 # text = 平均數呢？
 # translit = píngjūnshùne?
-1	平均數	平均數	NOUN	_	_	0	root	_	SpaceAfter=No|Translit=píngjūnshù|LTranslit=píngjūnshù
+1	平均數	平均數	NOUN	_	_	0	root	_	SpaceAfter=No|Translit=píngjūnshù|LTranslit=píngjūnshù|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=ne|LTranslit=ne
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -1853,7 +1853,7 @@
 6	新	新	ADJ	_	_	7	amod	_	SpaceAfter=No|Translit=xīn|LTranslit=xīn
 7	碟	碟	NOUN	_	_	9	obj:periph	_	SpaceAfter=No|Translit=dié|LTranslit=dié
 8	你	你	PRON	_	_	9	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-9	聽	聽	VERB	_	_	1	parataxis	_	SpaceAfter=No|Translit=tīng|LTranslit=tīng
+9	聽	聽	VERB	_	_	1	parataxis	_	SpaceAfter=No|Translit=tīng|LTranslit=tīng|Cxn=Interrogative-Polar-Direct|CxnElt=9:Interrogative-Polar-Direct.Clause
 10	過	過	AUX	_	_	9	aux	_	SpaceAfter=No|Translit=guò|LTranslit=guò
 11	了	了	AUX	_	_	9	aux	_	SpaceAfter=No|Translit=le|LTranslit=le
 12	嗎	嗎	PART	_	_	9	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
@@ -1863,8 +1863,8 @@
 # text = 當然有楊千嬅！
 # translit = dāngrányǒuyángqiān嬅!
 1	當然	當然	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=dāngrán|LTranslit=dāngrán
-2	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-3	楊千嬅	楊千嬅	PROPN	_	_	2	obj	_	SpaceAfter=No|Translit=yángqiān嬅|LTranslit=yángqiān嬅
+2	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+3	楊千嬅	楊千嬅	PROPN	_	_	2	obj	_	SpaceAfter=No|Translit=yángqiān嬅|LTranslit=yángqiān嬅|CxnElt=2:Existential-HavePred.Pivot
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 193
@@ -1880,7 +1880,7 @@
 # text = 未聽過？
 # translit = wèitīngguò?
 1	未	未	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
-2	聽	聽	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tīng|LTranslit=tīng
+2	聽	聽	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tīng|LTranslit=tīng|Cxn=Interrogative-Reduced|CxnElt=2:Interrogative-Reduced.Clause
 3	過	過	AUX	_	_	2	aux	_	SpaceAfter=No|Translit=guò|LTranslit=guò
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -1904,7 +1904,7 @@
 # sent_id = 197
 # text = 黎明？
 # translit = límíng?
-1	黎明	黎明	PROPN	_	_	0	root	_	SpaceAfter=No|Translit=límíng|LTranslit=límíng
+1	黎明	黎明	PROPN	_	_	0	root	_	SpaceAfter=No|Translit=límíng|LTranslit=límíng|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 198
@@ -1919,8 +1919,8 @@
 # translit = guānnǐshénmeshì?
 1	關	關	VERB	_	_	0	root	_	SpaceAfter=No|Translit=guān|LTranslit=guān
 2	你	你	PRON	_	_	4	nmod	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-3	什麼	什麼	DET	_	_	4	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
-4	事	事	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+3	什麼	什麼	DET	_	_	4	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=4:Interrogative-WHInfo-Direct.WHWord
+4	事	事	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 200
@@ -1929,7 +1929,7 @@
 1	喂	喂	INTJ	_	_	4	discourse	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 3	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-4	幹麼	幹麼	VERB	_	_	0	root	_	SpaceAfter=No|Translit=幹me|LTranslit=幹me
+4	幹麼	幹麼	VERB	_	_	0	root	_	SpaceAfter=No|Translit=幹me|LTranslit=幹me|Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause,4:Interrogative-WHInfo-Direct.WHWord
 5	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 201
@@ -1946,8 +1946,8 @@
 # translit = kāidiànshì幹shénme?
 1	開	開	VERB	_	_	3	advcl	_	SpaceAfter=No|Translit=kāi|LTranslit=kāi
 2	電視	電視	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=diànshì|LTranslit=diànshì
-3	幹	幹	VERB	_	_	0	root	_	SpaceAfter=No|Translit=幹|LTranslit=幹
-4	什麼	什麼	PRON	_	_	3	obj	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
+3	幹	幹	VERB	_	_	0	root	_	SpaceAfter=No|Translit=幹|LTranslit=幹|Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
+4	什麼	什麼	PRON	_	_	3	obj	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=3:Interrogative-WHInfo-Direct.WHWord
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 203
@@ -2029,8 +2029,8 @@
 # text = 是誰打電話來的？
 # translit = shìshuídǎdiànhuàláide?
 1	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
-2	誰	誰	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=shuí|LTranslit=shuí
-3	打	打	VERB	_	_	1	ccomp	_	SpaceAfter=No|Translit=dǎ|LTranslit=dǎ
+2	誰	誰	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=shuí|LTranslit=shuí|CxnElt=3:Interrogative-WHInfo-Direct.WHWord
+3	打	打	VERB	_	_	1	ccomp	_	SpaceAfter=No|Translit=dǎ|LTranslit=dǎ|Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	電話	電話	NOUN	_	_	3	obj	_	SpaceAfter=No|Translit=diànhuà|LTranslit=diànhuà
 5	來	來	VERB	_	_	3	compound:dir	_	SpaceAfter=No|Translit=lái|LTranslit=lái
 6	的	的	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=de|LTranslit=de
@@ -2041,21 +2041,21 @@
 # translit = guānnǐshénmeshì?
 1	關	關	VERB	_	_	0	root	_	SpaceAfter=No|Translit=guān|LTranslit=guān
 2	你	你	PRON	_	_	4	nmod	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-3	什麼	什麼	DET	_	_	4	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
-4	事	事	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+3	什麼	什麼	DET	_	_	4	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=4:Interrogative-WHInfo-Direct.WHWord
+4	事	事	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 213
 # text = 喂？
 # translit = wèi?
-1	喂	喂	INTJ	_	_	0	root	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
+1	喂	喂	INTJ	_	_	0	root	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 214
 # text = 聽到嗎？
 # translit = tīngdàoma?
-1	聽	聽	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tīng|LTranslit=tīng
-2	到	到	VERB	_	_	1	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+1	聽	聽	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tīng|LTranslit=tīng|Cxn=Interrogative-Polar-Direct,Resultative|CxnElt=1:Interrogative-Polar-Direct.Clause,1:Resultative.Event
+2	到	到	VERB	_	_	1	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=1:Resultative.ResultState
 3	嗎	嗎	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 4	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -2085,7 +2085,7 @@
 # text = 你覺得陳奕迅同楊千嬅最後會一起嗎？
 # translit = nǐjuédechén奕xùntóngyángqiān嬅zuìhòuhuìyīqǐma?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-2	覺得	覺得	VERB	_	_	0	root	_	SpaceAfter=No|Translit=juéde|LTranslit=juéde
+2	覺得	覺得	VERB	_	_	0	root	_	SpaceAfter=No|Translit=juéde|LTranslit=juéde|Cxn=Interrogative-Polar-Direct|CxnElt=2:Interrogative-Polar-Direct.Clause
 3	陳奕迅	陳奕迅	PROPN	_	_	8	nsubj	_	SpaceAfter=No|Translit=chén奕xùn|LTranslit=chén奕xùn
 4	同	同	CCONJ	_	_	5	cc	_	SpaceAfter=No|Translit=tóng|LTranslit=tóng
 5	楊千嬅	楊千嬅	PROPN	_	_	3	conj	_	SpaceAfter=No|Translit=yángqiān嬅|LTranslit=yángqiān嬅
@@ -2101,7 +2101,7 @@
 1	不	不	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
 2	是	是	AUX	_	_	4	cop	_	SpaceAfter=No|Translit=shì|LTranslit=shì
 3	蠻	蠻	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=蠻|LTranslit=蠻
-4	合襯	合襯	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=héchèn|LTranslit=héchèn
+4	合襯	合襯	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=héchèn|LTranslit=héchèn|Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause
 5	嗎	嗎	PART	_	_	4	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 6	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -2111,8 +2111,8 @@
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 2	說	說	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shuō|LTranslit=shuō
 3	陳奕迅	陳奕迅	PROPN	_	_	4	nsubj	_	SpaceAfter=No|Translit=chén奕xùn|LTranslit=chén奕xùn
-4	有	有	VERB	_	_	2	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-5	什麼	什麼	PRON	_	_	4	obj	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
+4	有	有	VERB	_	_	2	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
+5	什麼	什麼	PRON	_	_	4	obj	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 6	不	不	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
 7	好	好	ADJ	_	_	5	acl	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
 8	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -2122,8 +2122,8 @@
 # translit = zàiwèiyǒuMP3deniándài,diàntáibōshénmegē,wǒmenjiùliúxínggē.
 1	在	在	ADP	_	_	6	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
 2	未	未	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
-3	有	有	VERB	_	_	6	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-4	MP3	MP3	NOUN	_	_	3	obj	_	SpaceAfter=No|Translit=MP3|LTranslit=MP3
+3	有	有	VERB	_	_	6	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+4	MP3	MP3	NOUN	_	_	3	obj	_	SpaceAfter=No|Translit=MP3|LTranslit=MP3|CxnElt=3:Existential-HavePred.Pivot
 5	的	的	ADP	_	_	3	mark:rel	_	SpaceAfter=No|Translit=de|LTranslit=de
 6	年代	年代	NOUN	_	_	15	obl:tmod	_	SpaceAfter=No|Translit=niándài|LTranslit=niándài
 7	，	，	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
@@ -2146,10 +2146,10 @@
 3	與	與	CCONJ	_	_	4	cc	_	SpaceAfter=No|Translit=yǔ|LTranslit=yǔ
 4	新城電台	新城電台	PROPN	_	_	2	conj	_	SpaceAfter=No|Translit=xīnchéngdiàntái|LTranslit=xīnchéngdiàntái
 5	間	間	NOUN	_	_	2	case:loc	_	SpaceAfter=No|Translit=jiān|LTranslit=jiān
-6	轉	轉	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhuǎn|LTranslit=zhuǎn
-7	來	來	VERB	_	_	6	compound:vv	_	SpaceAfter=No|Translit=lái|LTranslit=lái
-8	轉	轉	VERB	_	_	6	conj	_	SpaceAfter=No|Translit=zhuǎn|LTranslit=zhuǎn
-9	去	去	VERB	_	_	8	compound:vv	_	SpaceAfter=No|Translit=qù|LTranslit=qù
+6	轉	轉	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhuǎn|LTranslit=zhuǎn|Cxn=Resultative|CxnElt=6:Resultative.Event
+7	來	來	VERB	_	_	6	compound:vv	_	SpaceAfter=No|Translit=lái|LTranslit=lái|CxnElt=6:Resultative.ResultState
+8	轉	轉	VERB	_	_	6	conj	_	SpaceAfter=No|Translit=zhuǎn|LTranslit=zhuǎn|Cxn=Resultative|CxnElt=8:Resultative.Event
+9	去	去	VERB	_	_	8	compound:vv	_	SpaceAfter=No|Translit=qù|LTranslit=qù|CxnElt=8:Resultative.ResultState
 10	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 222
@@ -2266,8 +2266,8 @@
 2	在	在	ADP	_	_	3	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
 3	小時候	小時候	NOUN	_	_	5	obl:tmod	_	SpaceAfter=No|Translit=xiǎoshíhou|LTranslit=xiǎoshíhou
 4	反而	反而	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=fǎn'ér|LTranslit=fǎn'ér
-5	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-6	錢	錢	NOUN	_	_	5	obj	_	SpaceAfter=No|Translit=qián|LTranslit=qián
+5	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+6	錢	錢	NOUN	_	_	5	obj	_	SpaceAfter=No|Translit=qián|LTranslit=qián|CxnElt=5:Existential-HavePred.Pivot
 7	能	能	AUX	_	_	15	aux	_	SpaceAfter=No|Translit=néng|LTranslit=néng
 8	把	把	ADP	_	_	12	case	_	SpaceAfter=No|Translit=bǎ|LTranslit=bǎ
 9	想	想	AUX	_	_	10	aux	_	SpaceAfter=No|Translit=xiǎng|LTranslit=xiǎng
@@ -2337,14 +2337,14 @@
 # translit = rúguǒ'āyefāxiànwǒmenbùzàidàjiālè,jiùcǎnle.
 1	如果	如果	SCONJ	_	_	3	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
 2	阿爺	阿爺	NOUN	_	_	3	nsubj	_	SpaceAfter=No|Translit='āye|LTranslit='āye
-3	發現	發現	VERB	_	_	10	advcl	_	SpaceAfter=No|Translit=fāxiàn|LTranslit=fāxiàn
+3	發現	發現	VERB	_	_	10	advcl	_	SpaceAfter=No|Translit=fāxiàn|LTranslit=fāxiàn|CxnElt=10:Conditional-NeutralEpistemic.Protasis
 4	我們	我	PRON	_	_	6	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
 5	不	不	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
 6	在	在	VERB	_	_	3	ccomp	_	SpaceAfter=No|Translit=zài|LTranslit=zài
 7	大家樂	大家樂	PROPN	_	_	6	obj	_	SpaceAfter=No|Translit=dàjiālè|LTranslit=dàjiālè
 8	，	，	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 9	就	就	ADV	_	_	10	advmod	_	SpaceAfter=No|Translit=jiù|LTranslit=jiù
-10	慘	慘	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=cǎn|LTranslit=cǎn
+10	慘	慘	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=cǎn|LTranslit=cǎn|Cxn=Conditional-NeutralEpistemic|CxnElt=10:Conditional-NeutralEpistemic.Apodosis
 11	了	了	PART	_	_	10	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 12	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
@@ -2377,12 +2377,12 @@
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 2	沒	沒	PART	_	Polarity=Neg	4	advmod	_	SpaceAfter=No|Translit=méi|LTranslit=méi
 3	一起	一起	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=yīqǐ|LTranslit=yīqǐ
-4	聽	聽	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tīng|LTranslit=tīng
+4	聽	聽	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tīng|LTranslit=tīng|Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause
 5	嗎	嗎	PART	_	_	4	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 6	？	？	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 7	沒	沒	PART	_	Polarity=Neg	9	advmod	_	SpaceAfter=No|Translit=méi|LTranslit=méi
 8	一起	一起	ADV	_	_	9	advmod	_	SpaceAfter=No|Translit=yīqǐ|LTranslit=yīqǐ
-9	唱	唱	VERB	_	_	4	conj	_	SpaceAfter=No|Translit=chàng|LTranslit=chàng
+9	唱	唱	VERB	_	_	4	conj	_	SpaceAfter=No|Translit=chàng|LTranslit=chàng|Cxn=Interrogative-Polar-Direct|CxnElt=9:Interrogative-Polar-Direct.Clause
 10	嗎	嗎	PART	_	_	9	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 11	？	？	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -2408,7 +2408,7 @@
 # sent_id = 240
 # text = 給你兩元吧？
 # translit = gěinǐliǎngyuánba?
-1	給	給	VERB	_	_	0	root	_	SpaceAfter=No|Translit=gěi|LTranslit=gěi
+1	給	給	VERB	_	_	0	root	_	SpaceAfter=No|Translit=gěi|LTranslit=gěi|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
 2	你	你	PRON	_	_	1	iobj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 3	兩	兩	NUM	_	_	4	nummod	_	SpaceAfter=No|Translit=liǎng|LTranslit=liǎng
 4	元	元	NOUN	_	NounType=Clf	1	obj	_	SpaceAfter=No|Translit=yuán|LTranslit=yuán
@@ -2469,7 +2469,7 @@
 # sent_id = 247
 # text = 傻的嗎？
 # translit = shǎdema?
-1	傻	傻	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=shǎ|LTranslit=shǎ
+1	傻	傻	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=shǎ|LTranslit=shǎ|Cxn=Interrogative-Polar-Direct|CxnElt=1:Interrogative-Polar-Direct.Clause
 2	的	的	PART	_	_	1	mark:rel	_	SpaceAfter=No|Translit=de|LTranslit=de
 3	嗎	嗎	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 4	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -2537,7 +2537,7 @@
 # text = 這樣可以了吧？
 # translit = zhèyàngkěyǐleba?
 1	這樣	這樣	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zhèyàng|LTranslit=zhèyàng
-2	可以	可以	AUX	_	_	0	root	_	SpaceAfter=No|Translit=kěyǐ|LTranslit=kěyǐ
+2	可以	可以	AUX	_	_	0	root	_	SpaceAfter=No|Translit=kěyǐ|LTranslit=kěyǐ|Cxn=Interrogative-Reduced|CxnElt=2:Interrogative-Reduced.Clause
 3	了	了	PART	_	_	2	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 4	吧	吧	PART	_	_	2	discourse:sp	_	SpaceAfter=No|Translit=ba|LTranslit=ba
 5	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -2693,8 +2693,8 @@
 1	都	都	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=dōu|LTranslit=dōu
 2	不	不	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
 3	知	知	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhī|LTranslit=zhī
-4	有	有	VERB	_	_	3	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-5	什麼	什麼	DET	_	_	4	obj	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
+4	有	有	VERB	_	_	3	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+5	什麼	什麼	DET	_	_	4	obj	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=4:Existential-HavePred.Pivot
 6	好	好	VERB	_	_	5	acl	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
 7	聽	聽	VERB	_	_	6	xcomp	_	SpaceAfter=No|Translit=tīng|LTranslit=tīng
 8	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
@@ -2717,7 +2717,7 @@
 # text = 要用三角形內角總和嗎？
 # translit = yàoyòngsānjiǎoxíngnèijiǎozǒnghéma?
 1	要	要	AUX	_	_	2	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
-2	用	用	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yòng|LTranslit=yòng
+2	用	用	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yòng|LTranslit=yòng|Cxn=Interrogative-Polar-Direct|CxnElt=2:Interrogative-Polar-Direct.Clause
 3	三角形內角總和	三角形內角總和	PROPN	_	_	2	obj	_	SpaceAfter=No|Translit=sānjiǎoxíngnèijiǎozǒnghé|LTranslit=sānjiǎoxíngnèijiǎozǒnghé
 4	嗎	嗎	PART	_	_	2	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 5	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -2732,7 +2732,7 @@
 # text = 你完成了？
 # translit = nǐwánchéngle?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-2	完成	完成	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wánchéng|LTranslit=wánchéng
+2	完成	完成	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wánchéng|LTranslit=wánchéng|Cxn=Interrogative-Reduced|CxnElt=2:Interrogative-Reduced.Clause
 3	了	了	PART	_	_	2	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -2752,8 +2752,8 @@
 4	很	很	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=hěn|LTranslit=hěn
 5	多	多	ADJ	_	_	3	obj	_	SpaceAfter=No|Translit=duō|LTranslit=duō
 6	未	未	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
-7	做	做	VERB	_	_	5	acl	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò
-8	好	好	ADJ	_	_	7	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
+7	做	做	VERB	_	_	5	acl	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò|Cxn=Resultative|CxnElt=7:Resultative.Event
+8	好	好	ADJ	_	_	7	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo|CxnElt=7:Resultative.ResultState
 9	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 273
@@ -2771,7 +2771,7 @@
 # translit = nǐkěyǐbìzuǐma?
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 2	可以	可以	AUX	_	_	3	aux	_	SpaceAfter=No|Translit=kěyǐ|LTranslit=kěyǐ
-3	閉嘴	閉嘴	VERB	_	_	0	root	_	SpaceAfter=No|Translit=bìzuǐ|LTranslit=bìzuǐ
+3	閉嘴	閉嘴	VERB	_	_	0	root	_	SpaceAfter=No|Translit=bìzuǐ|LTranslit=bìzuǐ|Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	嗎	嗎	PART	_	_	3	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -2809,10 +2809,10 @@
 1	不	不	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
 2	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
 3	只	只	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=zhǐ|LTranslit=zhǐ
-4	有	有	VERB	_	_	6	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-5	你	你	PRON	_	_	4	obj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-6	有	有	VERB	_	_	2	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-7	功課	功課	NOUN	_	_	6	obj	_	SpaceAfter=No|Translit=gōngkè|LTranslit=gōngkè
+4	有	有	VERB	_	_	6	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+5	你	你	PRON	_	_	4	obj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ|CxnElt=4:Existential-HavePred.Pivot
+6	有	有	VERB	_	_	2	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+7	功課	功課	NOUN	_	_	6	obj	_	SpaceAfter=No|Translit=gōngkè|LTranslit=gōngkè|CxnElt=6:Existential-HavePred.Pivot
 8	做	做	VERB	_	_	7	acl	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò
 9	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
@@ -2878,7 +2878,7 @@
 # sent_id = 286
 # text = 喂？
 # translit = wèi?
-1	喂	喂	INTJ	_	_	0	root	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
+1	喂	喂	INTJ	_	_	0	root	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 287
@@ -2964,9 +2964,9 @@
 # sent_id = 295
 # text = 為什麼要借給你？
 # translit = wèishénmeyàojiègěinǐ?
-1	為什麼	為什麼	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=wèishénme|LTranslit=wèishénme
+1	為什麼	為什麼	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=wèishénme|LTranslit=wèishénme|CxnElt=3:Interrogative-WHInfo-Direct.WHWord
 2	要	要	AUX	_	_	3	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
-3	借	借	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jiè|LTranslit=jiè
+3	借	借	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jiè|LTranslit=jiè|Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	給	給	ADP	_	_	5	case	_	SpaceAfter=No|Translit=gěi|LTranslit=gěi
 5	你	你	PRON	_	_	3	obl	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 6	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -2998,8 +2998,8 @@
 # translit = guānwǒshénmeshì?
 1	關	關	VERB	_	_	0	root	_	SpaceAfter=No|Translit=guān|LTranslit=guān
 2	我	我	PRON	_	_	4	nmod	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
-3	什麼	什麼	DET	_	_	4	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
-4	事	事	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+3	什麼	什麼	DET	_	_	4	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=4:Interrogative-WHInfo-Direct.WHWord
+4	事	事	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 299
@@ -3026,8 +3026,8 @@
 # sent_id = 301
 # text = 嚇死人了！
 # translit = xiàsǐrénle!
-1	嚇	嚇	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xià|LTranslit=xià
-2	死	死	VERB	_	_	1	compound:vv	_	SpaceAfter=No|Translit=sǐ|LTranslit=sǐ
+1	嚇	嚇	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xià|LTranslit=xià|Cxn=Resultative|CxnElt=1:Resultative.Event
+2	死	死	VERB	_	_	1	compound:vv	_	SpaceAfter=No|Translit=sǐ|LTranslit=sǐ|CxnElt=1:Resultative.ResultState
 3	人	人	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén
 4	了	了	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 5	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
@@ -3037,7 +3037,7 @@
 # translit = nǐzài幹me?
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 2	在	在	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=zài|LTranslit=zài
-3	幹麼	幹麼	VERB	_	_	0	root	_	SpaceAfter=No|Translit=幹me|LTranslit=幹me
+3	幹麼	幹麼	VERB	_	_	0	root	_	SpaceAfter=No|Translit=幹me|LTranslit=幹me|Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause,3:Interrogative-WHInfo-Direct.WHWord
 4	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 303
@@ -3062,8 +3062,8 @@
 # sent_id = 305
 # text = 刷好快些去睡！
 # translit = shuāhǎokuàixiēqùshuì!
-1	刷	刷	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shuā|LTranslit=shuā
-2	好	好	ADJ	_	_	1	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
+1	刷	刷	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shuā|LTranslit=shuā|Cxn=Resultative|CxnElt=1:Resultative.Event
+2	好	好	ADJ	_	_	1	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo|CxnElt=1:Resultative.ResultState
 3	快	快	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=kuài|LTranslit=kuài
 4	些	些	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=xiē|LTranslit=xiē
 5	去	去	VERB	_	_	1	conj	_	SpaceAfter=No|Translit=qù|LTranslit=qù
@@ -3080,7 +3080,7 @@
 # text = 又怎麼了？
 # translit = yòuzěnmele?
 1	又	又	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=yòu|LTranslit=yòu
-2	怎麼	怎麼	ADV	_	_	0	root	_	SpaceAfter=No|Translit=zěnme|LTranslit=zěnme
+2	怎麼	怎麼	ADV	_	_	0	root	_	SpaceAfter=No|Translit=zěnme|LTranslit=zěnme|Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause,2:Interrogative-WHInfo-Direct.WHWord
 3	了	了	PART	_	_	2	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -3095,8 +3095,8 @@
 # text = 小心吵醒爺爺！
 # translit = xiǎoxīnchǎoxǐngyeye!
 1	小心	小心	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=xiǎoxīn|LTranslit=xiǎoxīn
-2	吵	吵	VERB	_	_	1	ccomp	_	SpaceAfter=No|Translit=chǎo|LTranslit=chǎo
-3	醒	醒	VERB	_	_	2	compound:vv	_	SpaceAfter=No|Translit=xǐng|LTranslit=xǐng
+2	吵	吵	VERB	_	_	1	ccomp	_	SpaceAfter=No|Translit=chǎo|LTranslit=chǎo|Cxn=Resultative|CxnElt=2:Resultative.Event
+3	醒	醒	VERB	_	_	2	compound:vv	_	SpaceAfter=No|Translit=xǐng|LTranslit=xǐng|CxnElt=2:Resultative.ResultState
 4	爺爺	爺爺	NOUN	_	_	2	obj	_	SpaceAfter=No|Translit=yeye|LTranslit=yeye
 5	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
@@ -3106,7 +3106,7 @@
 1	那	那	DET	_	_	4	discourse	_	SpaceAfter=No|Translit=nà|LTranslit=nà
 2	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 3	要	要	AUX	_	_	4	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
-4	幹麼	幹麼	VERB	_	_	0	root	_	SpaceAfter=No|Translit=幹me|LTranslit=幹me
+4	幹麼	幹麼	VERB	_	_	0	root	_	SpaceAfter=No|Translit=幹me|LTranslit=幹me|Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause,4:Interrogative-WHInfo-Direct.WHWord
 5	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 311
@@ -3145,10 +3145,10 @@
 1	中間	中間	NOUN	_	_	4	obl	_	SpaceAfter=No|Translit=zhōngjiān|LTranslit=zhōngjiān
 2	不	不	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
 3	要	要	AUX	_	_	4	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
-4	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-5	空白	空白	NOUN	_	_	4	obj	_	SpaceAfter=No|Translit=kōngbái|LTranslit=kōngbái
+4	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+5	空白	空白	NOUN	_	_	4	obj	_	SpaceAfter=No|Translit=kōngbái|LTranslit=kōngbái|CxnElt=4:Existential-HavePred.Pivot
 6	，	，	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-7	明白	明白	VERB	_	_	4	parataxis	_	SpaceAfter=No|Translit=míngbái|LTranslit=míngbái
+7	明白	明白	VERB	_	_	4	parataxis	_	SpaceAfter=No|Translit=míngbái|LTranslit=míngbái|Cxn=Interrogative-Polar-Direct|CxnElt=7:Interrogative-Polar-Direct.Clause
 8	嗎	嗎	PART	_	_	7	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 9	？	？	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -3157,9 +3157,9 @@
 # translit = duìwǒyǒushénmehǎochù?
 1	對	對	ADP	_	_	2	case	_	SpaceAfter=No|Translit=duì|LTranslit=duì
 2	我	我	PRON	_	_	3	obl	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
-3	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-4	什麼	什麼	DET	_	_	5	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
-5	好處	好處	NOUN	_	_	3	obj	_	SpaceAfter=No|Translit=hǎochù|LTranslit=hǎochù
+3	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+4	什麼	什麼	DET	_	_	5	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=5:Interrogative-WHInfo-Direct.WHWord
+5	好處	好處	NOUN	_	_	3	obj	_	SpaceAfter=No|Translit=hǎochù|LTranslit=hǎochù|Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Existential-HavePred.Pivot,5:Interrogative-WHInfo-Direct.Clause
 6	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 316
@@ -3167,7 +3167,7 @@
 # translit = nǐbùbāng?
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 2	不	不	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-3	幫	幫	VERB	_	_	0	root	_	SpaceAfter=No|Translit=bāng|LTranslit=bāng
+3	幫	幫	VERB	_	_	0	root	_	SpaceAfter=No|Translit=bāng|LTranslit=bāng|Cxn=Interrogative-Reduced|CxnElt=3:Interrogative-Reduced.Clause
 4	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 317
@@ -3251,7 +3251,7 @@
 # translit = dìyīshǒuyǒuduōzhǎng?
 1	第一	第一	ADJ	_	_	2	amod	_	SpaceAfter=No|Translit=dìyī|LTranslit=dìyī
 2	首	首	NOUN	_	NounType=Clf	3	nsubj	_	SpaceAfter=No|Translit=shǒu|LTranslit=shǒu
-3	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
+3	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Interrogative-Reduced|CxnElt=3:Interrogative-Reduced.Clause
 4	多	多	DET	_	_	5	det	_	SpaceAfter=No|Translit=duō|LTranslit=duō
 5	長	長	ADJ	_	_	3	ccomp	_	SpaceAfter=No|Translit=zhǎng|LTranslit=zhǎng
 6	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -3268,7 +3268,7 @@
 # sent_id = 328
 # text = 什麼來的？
 # translit = shénmeláide?
-1	什麼	什麼	DET	_	_	0	root	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
+1	什麼	什麼	DET	_	_	0	root	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	來	來	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=lái|LTranslit=lái
 3	的	的	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=de|LTranslit=de
 4	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -3340,8 +3340,8 @@
 # sent_id = 332
 # text = 收拾好！
 # translit = shōushihǎo!
-1	收拾	收拾	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shōushi|LTranslit=shōushi
-2	好	好	ADJ	_	_	1	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
+1	收拾	收拾	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shōushi|LTranslit=shōushi|Cxn=Resultative|CxnElt=1:Resultative.Event
+2	好	好	ADJ	_	_	1	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo|CxnElt=1:Resultative.ResultState
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 333
@@ -3395,7 +3395,7 @@
 # text = 又聽？
 # translit = yòutīng?
 1	又	又	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=yòu|LTranslit=yòu
-2	聽	聽	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tīng|LTranslit=tīng
+2	聽	聽	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tīng|LTranslit=tīng|Cxn=Interrogative-Reduced|CxnElt=2:Interrogative-Reduced.Clause
 3	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 339
@@ -3418,13 +3418,13 @@
 # sent_id = 341
 # text = 接收不到，你弄壞了。
 # translit = jiēshōubùdào,nǐnònghuàile.
-1	接收	接收	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jiēshōu|LTranslit=jiēshōu
+1	接收	接收	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jiēshōu|LTranslit=jiēshōu|Cxn=Resultative|CxnElt=1:Resultative.Event
 2	不	不	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-3	到	到	VERB	_	_	1	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+3	到	到	VERB	_	_	1	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=1:Resultative.ResultState
 4	，	，	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 5	你	你	PRON	_	_	6	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-6	弄	弄	VERB	_	_	1	parataxis	_	SpaceAfter=No|Translit=nòng|LTranslit=nòng
-7	壞	壞	VERB	_	_	6	compound:vv	_	SpaceAfter=No|Translit=huài|LTranslit=huài
+6	弄	弄	VERB	_	_	1	parataxis	_	SpaceAfter=No|Translit=nòng|LTranslit=nòng|Cxn=Resultative|CxnElt=6:Resultative.Event
+7	壞	壞	VERB	_	_	6	compound:vv	_	SpaceAfter=No|Translit=huài|LTranslit=huài|CxnElt=6:Resultative.ResultState
 8	了	了	AUX	_	_	6	aux	_	SpaceAfter=No|Translit=le|LTranslit=le
 9	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
@@ -3433,8 +3433,8 @@
 # translit = nǐkuàinònghǎohuíláiya.
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 2	快	快	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=kuài|LTranslit=kuài
-3	弄	弄	VERB	_	_	0	root	_	SpaceAfter=No|Translit=nòng|LTranslit=nòng
-4	好	好	ADJ	_	_	3	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
+3	弄	弄	VERB	_	_	0	root	_	SpaceAfter=No|Translit=nòng|LTranslit=nòng|Cxn=Resultative|CxnElt=3:Resultative.Event
+4	好	好	ADJ	_	_	3	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo|CxnElt=3:Resultative.ResultState
 5	回來	回來	VERB	_	_	3	conj	_	SpaceAfter=No|Translit=huílái|LTranslit=huílái
 6	呀	呀	PART	_	_	3	discourse:sp	_	SpaceAfter=No|Translit=ya|LTranslit=ya
 7	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
@@ -3452,16 +3452,16 @@
 # text = 仍接收不到。
 # translit = réngjiēshōubùdào.
 1	仍	仍	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=réng|LTranslit=réng
-2	接收	接收	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jiēshōu|LTranslit=jiēshōu
+2	接收	接收	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jiēshōu|LTranslit=jiēshōu|Cxn=Resultative|CxnElt=2:Resultative.Event
 3	不	不	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-4	到	到	VERB	_	_	2	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+4	到	到	VERB	_	_	2	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=2:Resultative.ResultState
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 345
 # text = 舉高收音機。
 # translit = jǔgāoshōuyīnjī.
-1	舉	舉	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jǔ|LTranslit=jǔ
-2	高	高	ADJ	_	_	1	compound:vv	_	SpaceAfter=No|Translit=gāo|LTranslit=gāo
+1	舉	舉	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jǔ|LTranslit=jǔ|Cxn=Resultative|CxnElt=1:Resultative.Event
+2	高	高	ADJ	_	_	1	compound:vv	_	SpaceAfter=No|Translit=gāo|LTranslit=gāo|CxnElt=1:Resultative.ResultState
 3	收音機	收音機	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=shōuyīnjī|LTranslit=shōuyīnjī
 4	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
@@ -3519,21 +3519,21 @@
 # text = 再舉高試試收不收到。
 # translit = zàijǔgāoshìshìshōubùshōudào.
 1	再	再	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zài|LTranslit=zài
-2	舉	舉	VERB	_	_	4	advcl	_	SpaceAfter=No|Translit=jǔ|LTranslit=jǔ
-3	高	高	ADJ	_	_	2	compound:vv	_	SpaceAfter=No|Translit=gāo|LTranslit=gāo
+2	舉	舉	VERB	_	_	4	advcl	_	SpaceAfter=No|Translit=jǔ|LTranslit=jǔ|Cxn=Resultative|CxnElt=2:Resultative.Event
+3	高	高	ADJ	_	_	2	compound:vv	_	SpaceAfter=No|Translit=gāo|LTranslit=gāo|CxnElt=2:Resultative.ResultState
 4	試試	試試	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shìshì|LTranslit=shìshì
-5	收	收	VERB	_	_	4	ccomp	_	SpaceAfter=No|Translit=shōu|LTranslit=shōu
+5	收	收	VERB	_	_	4	ccomp	_	SpaceAfter=No|Translit=shōu|LTranslit=shōu|Cxn=Interrogative-Polar-Direct|CxnElt=5:Interrogative-Polar-Direct.Clause
 6	不	不	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-7	收	收	VERB	_	_	5	conj	_	SpaceAfter=No|Translit=shōu|LTranslit=shōu
-8	到	到	VERB	_	_	7	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+7	收	收	VERB	_	_	5	conj	_	SpaceAfter=No|Translit=shōu|LTranslit=shōu|Cxn=Resultative|CxnElt=7:Resultative.Event
+8	到	到	VERB	_	_	7	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=7:Resultative.ResultState
 9	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 352
 # text = 再舉高。
 # translit = zàijǔgāo.
 1	再	再	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zài|LTranslit=zài
-2	舉	舉	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jǔ|LTranslit=jǔ
-3	高	高	ADJ	_	_	2	compound:vv	_	SpaceAfter=No|Translit=gāo|LTranslit=gāo
+2	舉	舉	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jǔ|LTranslit=jǔ|Cxn=Resultative|CxnElt=2:Resultative.Event
+3	高	高	ADJ	_	_	2	compound:vv	_	SpaceAfter=No|Translit=gāo|LTranslit=gāo|CxnElt=2:Resultative.ResultState
 4	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 353
@@ -3551,8 +3551,8 @@
 2	要	要	VERB	_	_	8	advcl	_	SpaceAfter=No|Translit=yào|LTranslit=yào
 3	我	我	PRON	_	_	2	obj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 4	試	試	VERB	_	_	2	xcomp	_	SpaceAfter=No|Translit=shì|LTranslit=shì
-5	多少	多少	DET	_	_	6	det	_	SpaceAfter=No|Translit=duōshǎo|LTranslit=duōshǎo
-6	次	次	NOUN	_	NounType=Clf	4	obj	_	SpaceAfter=No|Translit=cì|LTranslit=cì
+5	多少	多少	DET	_	_	6	det	_	SpaceAfter=No|Translit=duōshǎo|LTranslit=duōshǎo|CxnElt=6:Interrogative-WHInfo-Direct.WHWord
+6	次	次	NOUN	_	NounType=Clf	4	obj	_	SpaceAfter=No|Translit=cì|LTranslit=cì|Cxn=Interrogative-WHInfo-Direct|CxnElt=6:Interrogative-WHInfo-Direct.Clause
 7	才	才	ADV	_	_	8	advmod	_	SpaceAfter=No|Translit=cái|LTranslit=cái
 8	行	行	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xíng|LTranslit=xíng
 9	？	？	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -3582,8 +3582,8 @@
 # translit = shìnǐnònghuàide.
 1	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
 2	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-3	弄	弄	VERB	_	_	1	ccomp	_	SpaceAfter=No|Translit=nòng|LTranslit=nòng
-4	壞	壞	ADJ	_	_	3	compound:vv	_	SpaceAfter=No|Translit=huài|LTranslit=huài
+3	弄	弄	VERB	_	_	1	ccomp	_	SpaceAfter=No|Translit=nòng|LTranslit=nòng|Cxn=Resultative|CxnElt=3:Resultative.Event
+4	壞	壞	ADJ	_	_	3	compound:vv	_	SpaceAfter=No|Translit=huài|LTranslit=huài|CxnElt=3:Resultative.ResultState
 5	的	的	PART	_	_	3	discourse:sp	_	SpaceAfter=No|Translit=de|LTranslit=de
 6	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
@@ -3593,8 +3593,8 @@
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 2	要	要	AUX	_	_	3	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
 3	負責	負責	VERB	_	_	0	root	_	SpaceAfter=No|Translit=fùzé|LTranslit=fùzé
-4	弄	弄	VERB	_	_	3	xcomp	_	SpaceAfter=No|Translit=nòng|LTranslit=nòng
-5	好	好	ADJ	_	_	4	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
+4	弄	弄	VERB	_	_	3	xcomp	_	SpaceAfter=No|Translit=nòng|LTranslit=nòng|Cxn=Resultative|CxnElt=4:Resultative.Event
+5	好	好	ADJ	_	_	4	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo|CxnElt=4:Resultative.ResultState
 6	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 359
@@ -3602,8 +3602,8 @@
 # translit = guānwǒshénmeshì?
 1	關	關	ADP	_	_	0	root	_	SpaceAfter=No|Translit=guān|LTranslit=guān
 2	我	我	PRON	_	_	4	nmod	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
-3	什麼	什麼	DET	_	_	4	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
-4	事	事	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+3	什麼	什麼	DET	_	_	4	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=4:Interrogative-WHInfo-Direct.WHWord
+4	事	事	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 360
@@ -3626,15 +3626,15 @@
 # translit = guānwǒshénmeshì?
 1	關	關	ADP	_	_	0	root	_	SpaceAfter=No|Translit=guān|LTranslit=guān
 2	我	我	PRON	_	_	4	nmod	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
-3	什麼	什麼	DET	_	_	4	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
-4	事	事	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+3	什麼	什麼	DET	_	_	4	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=4:Interrogative-WHInfo-Direct.WHWord
+4	事	事	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 363
 # text = 說快一點！
 # translit = shuōkuàiyīdiǎn!
-1	說	說	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shuō|LTranslit=shuō
-2	快	快	ADJ	_	_	1	compound:vv	_	SpaceAfter=No|Translit=kuài|LTranslit=kuài
+1	說	說	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shuō|LTranslit=shuō|Cxn=Resultative|CxnElt=1:Resultative.Event
+2	快	快	ADJ	_	_	1	compound:vv	_	SpaceAfter=No|Translit=kuài|LTranslit=kuài|CxnElt=1:Resultative.ResultState
 3	一點	一點	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=yīdiǎn|LTranslit=yīdiǎn
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
@@ -3643,8 +3643,8 @@
 # translit = guānwǒshénmeshì?
 1	關	關	ADP	_	_	0	root	_	SpaceAfter=No|Translit=guān|LTranslit=guān
 2	我	我	PRON	_	_	4	nmod	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
-3	什麼	什麼	DET	_	_	4	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
-4	事	事	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+3	什麼	什麼	DET	_	_	4	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=4:Interrogative-WHInfo-Direct.WHWord
+4	事	事	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 365
@@ -3663,8 +3663,8 @@
 # translit = guānwǒshénmeshì?
 1	關	關	ADP	_	_	0	root	_	SpaceAfter=No|Translit=guān|LTranslit=guān
 2	我	我	PRON	_	_	4	nmod	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
-3	什麼	什麼	DET	_	_	4	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
-4	事	事	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+3	什麼	什麼	DET	_	_	4	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=4:Interrogative-WHInfo-Direct.WHWord
+4	事	事	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 367
@@ -3676,8 +3676,8 @@
 # sent_id = 368
 # text = 有什麼好笑？
 # translit = yǒushénmehǎoxiào?
-1	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-2	什麼	什麼	DET	_	_	1	obj	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
+1	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred,Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause
+2	什麼	什麼	DET	_	_	1	obj	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=1:Existential-HavePred.Pivot,1:Interrogative-WHInfo-Direct.WHWord
 3	好	好	VERB	_	_	2	acl	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
 4	笑	笑	VERB	_	_	3	xcomp	_	SpaceAfter=No|Translit=xiào|LTranslit=xiào
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -3692,8 +3692,8 @@
 # sent_id = 370
 # text = 吵醒人啦！
 # translit = chǎoxǐngrénla!
-1	吵	吵	VERB	_	_	0	root	_	SpaceAfter=No|Translit=chǎo|LTranslit=chǎo
-2	醒	醒	VERB	_	_	1	compound:vv	_	SpaceAfter=No|Translit=xǐng|LTranslit=xǐng
+1	吵	吵	VERB	_	_	0	root	_	SpaceAfter=No|Translit=chǎo|LTranslit=chǎo|Cxn=Resultative|CxnElt=1:Resultative.Event
+2	醒	醒	VERB	_	_	1	compound:vv	_	SpaceAfter=No|Translit=xǐng|LTranslit=xǐng|CxnElt=1:Resultative.ResultState
 3	人	人	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén
 4	啦	啦	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=la|LTranslit=la
 5	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
@@ -3727,7 +3727,7 @@
 # text = 難度要我不穿拖鞋嗎？
 # translit = nándùyàowǒbùchuāntuōxiéma?
 1	難度	難度	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=nándù|LTranslit=nándù
-2	要	要	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yào|LTranslit=yào
+2	要	要	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yào|LTranslit=yào|Cxn=Interrogative-Polar-Direct|CxnElt=2:Interrogative-Polar-Direct.Clause
 3	我	我	PRON	_	_	2	obj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 4	不	不	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
 5	穿	穿	VERB	_	_	2	xcomp	_	SpaceAfter=No|Translit=chuān|LTranslit=chuān
@@ -3738,14 +3738,14 @@
 # sent_id = 375
 # text = 什麼？
 # translit = shénme?
-1	什麼	什麼	PRON	_	_	0	root	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
+1	什麼	什麼	PRON	_	_	0	root	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 376
 # text = 難度要我不穿拖鞋嗎？
 # translit = nándùyàowǒbùchuāntuōxiéma?
 1	難度	難度	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=nándù|LTranslit=nándù
-2	要	要	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yào|LTranslit=yào
+2	要	要	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yào|LTranslit=yào|Cxn=Interrogative-Polar-Direct|CxnElt=2:Interrogative-Polar-Direct.Clause
 3	我	我	PRON	_	_	2	obj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 4	不	不	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
 5	穿	穿	VERB	_	_	2	xcomp	_	SpaceAfter=No|Translit=chuān|LTranslit=chuān
@@ -3766,7 +3766,7 @@
 8	打	打	VERB	_	_	7	conj	_	SpaceAfter=No|Translit=dǎ|LTranslit=dǎ
 9	你	你	PRON	_	_	8	obj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 10	，	，	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-11	知道	知道	VERB	_	_	4	parataxis	_	SpaceAfter=No|Translit=zhīdào|LTranslit=zhīdào
+11	知道	知道	VERB	_	_	4	parataxis	_	SpaceAfter=No|Translit=zhīdào|LTranslit=zhīdào|Cxn=Interrogative-Polar-Direct|CxnElt=11:Interrogative-Polar-Direct.Clause
 12	嗎	嗎	PART	_	_	11	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 13	？	？	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -3781,7 +3781,7 @@
 # text = 你想我代爺爺打你嗎？
 # translit = nǐxiǎngwǒdàiyeyedǎnǐma?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-2	想	想	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xiǎng|LTranslit=xiǎng
+2	想	想	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xiǎng|LTranslit=xiǎng|Cxn=Interrogative-Polar-Direct|CxnElt=2:Interrogative-Polar-Direct.Clause
 3	我	我	PRON	_	_	6	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 4	代	代	ADP	_	_	5	case	_	SpaceAfter=No|Translit=dài|LTranslit=dài
 5	爺爺	爺爺	NOUN	_	_	6	obl	_	SpaceAfter=No|Translit=yeye|LTranslit=yeye
@@ -3795,7 +3795,7 @@
 # translit = háigǎnchǎoma?
 1	還	還	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=hái|LTranslit=hái
 2	敢	敢	AUX	_	_	3	aux	_	SpaceAfter=No|Translit=gǎn|LTranslit=gǎn
-3	吵	吵	VERB	_	_	0	root	_	SpaceAfter=No|Translit=chǎo|LTranslit=chǎo
+3	吵	吵	VERB	_	_	0	root	_	SpaceAfter=No|Translit=chǎo|LTranslit=chǎo|Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	嗎	嗎	PART	_	_	3	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -3829,7 +3829,7 @@
 3	我	我	PRON	_	_	2	obj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 4	出手	出手	VERB	_	_	2	xcomp	_	SpaceAfter=No|Translit=chūshǒu|LTranslit=chūshǒu
 5	才	才	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=cái|LTranslit=cái
-6	行	行	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xíng|LTranslit=xíng
+6	行	行	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xíng|LTranslit=xíng|Cxn=Interrogative-Reduced|CxnElt=6:Interrogative-Reduced.Clause
 7	？	？	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 385
@@ -3848,8 +3848,8 @@
 # translit = wǒjīntiānniǔdàode!
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 2	今天	今天	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No|Translit=jīntiān|LTranslit=jīntiān
-3	扭	扭	VERB	_	_	0	root	_	SpaceAfter=No|Translit=niǔ|LTranslit=niǔ
-4	到	到	VERB	_	_	3	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+3	扭	扭	VERB	_	_	0	root	_	SpaceAfter=No|Translit=niǔ|LTranslit=niǔ|Cxn=Resultative|CxnElt=3:Resultative.Event
+4	到	到	VERB	_	_	3	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=3:Resultative.ResultState
 5	的	的	PART	_	_	3	discourse:sp	_	SpaceAfter=No|Translit=de|LTranslit=de
 6	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
@@ -3932,7 +3932,7 @@
 2	是	是	AUX	_	_	5	cop	_	SpaceAfter=No|Translit=shì|LTranslit=shì
 3	這	這	DET	_	_	5	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
 4	一	一	NUM	_	_	5	nummod	_	SpaceAfter=No|Translit=yī|LTranslit=yī
-5	盒	盒	NOUN	_	NounType=Clf	0	root	_	SpaceAfter=No|Translit=hé|LTranslit=hé
+5	盒	盒	NOUN	_	NounType=Clf	0	root	_	SpaceAfter=No|Translit=hé|LTranslit=hé|Cxn=Interrogative-Reduced|CxnElt=5:Interrogative-Reduced.Clause
 6	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 394
@@ -4011,7 +4011,7 @@
 # sent_id = 404
 # text = 什麼？童年經典──《龍珠》主題曲。
 # translit = shénme?tóngniánjīngdiǎn──«lóngzhū»zhǔtíqū.
-1	什麼	什麼	PRON	_	_	0	root	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
+1	什麼	什麼	PRON	_	_	0	root	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 3	童年	童年	NOUN	_	_	4	compound	_	SpaceAfter=No|Translit=tóngnián|LTranslit=tóngnián
 4	經典	經典	NOUN	_	_	1	conj	_	SpaceAfter=No|Translit=jīngdiǎn|LTranslit=jīngdiǎn
@@ -4028,9 +4028,9 @@
 1	難怪	難怪	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=nánguài|LTranslit=nánguài
 2	那時	那時	ADV	_	_	4	obl:tmod	_	SpaceAfter=No|Translit=nàshí|LTranslit=nàshí
 3	他	他	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
-4	追	追	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhuī|LTranslit=zhuī
+4	追	追	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhuī|LTranslit=zhuī|Cxn=Resultative|CxnElt=4:Resultative.Event
 5	不	不	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-6	到	到	VERB	_	_	4	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+6	到	到	VERB	_	_	4	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=4:Resultative.ResultState
 7	那	那	DET	_	_	8	det	_	SpaceAfter=No|Translit=nà|LTranslit=nà
 8	女孩	女孩	NOUN	_	_	4	obj	_	SpaceAfter=No|Translit=nǚhái|LTranslit=nǚhái
 9	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
@@ -4042,7 +4042,7 @@
 2	部	部	NOUN	_	_	1	clf	_	SpaceAfter=No|Translit=bù|LTranslit=bù
 3	機	機	NOUN	_	NounType=Clf	5	nsubj	_	SpaceAfter=No|Translit=jī|LTranslit=jī
 4	還	還	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=hái|LTranslit=hái
-5	在	在	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zài|LTranslit=zài
+5	在	在	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zài|LTranslit=zài|Cxn=Interrogative-Polar-Direct|CxnElt=5:Interrogative-Polar-Direct.Clause
 6	嗎	嗎	PART	_	_	5	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 7	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -4058,17 +4058,17 @@
 # translit = jìngránnéngzhǎodào!
 1	竟然	竟然	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=jìngrán|LTranslit=jìngrán
 2	能	能	AUX	_	_	3	aux	_	SpaceAfter=No|Translit=néng|LTranslit=néng
-3	找	找	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhǎo|LTranslit=zhǎo
-4	到	到	VERB	_	_	3	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+3	找	找	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhǎo|LTranslit=zhǎo|Cxn=Resultative|CxnElt=3:Resultative.Event
+4	到	到	VERB	_	_	3	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=3:Resultative.ResultState
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 409
 # text = 怎會是這樣的？
 # translit = zěnhuìshìzhèyàngde?
-1	怎	怎	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=zěn|LTranslit=zěn
+1	怎	怎	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=zěn|LTranslit=zěn|CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	會	會	AUX	_	_	4	aux	_	SpaceAfter=No|Translit=huì|LTranslit=huì
 3	是	是	AUX	_	_	4	cop	_	SpaceAfter=No|Translit=shì|LTranslit=shì
-4	這樣	這樣	PRON	_	_	0	root	_	SpaceAfter=No|Translit=zhèyàng|LTranslit=zhèyàng
+4	這樣	這樣	PRON	_	_	0	root	_	SpaceAfter=No|Translit=zhèyàng|LTranslit=zhèyàng|Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	的	的	PART	_	_	4	discourse:sp	_	SpaceAfter=No|Translit=de|LTranslit=de
 6	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -4210,7 +4210,7 @@
 # sent_id = 419
 # text = 要我幫忙嗎？
 # translit = yàowǒbāngmángma?
-1	要	要	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yào|LTranslit=yào
+1	要	要	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yào|LTranslit=yào|Cxn=Interrogative-Polar-Direct|CxnElt=1:Interrogative-Polar-Direct.Clause
 2	我	我	PRON	_	_	1	obj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 3	幫忙	幫忙	VERB	_	_	1	xcomp	_	SpaceAfter=No|Translit=bāngmáng|LTranslit=bāngmáng
 4	嗎	嗎	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
@@ -4221,8 +4221,8 @@
 # translit = nòngdàonǎ裏qùle?
 1	弄	弄	VERB	_	_	0	root	_	SpaceAfter=No|Translit=nòng|LTranslit=nòng
 2	到	到	ADP	_	_	3	case	_	SpaceAfter=No|Translit=dào|LTranslit=dào
-3	哪裏	哪裏	PRON	_	_	4	obl	_	SpaceAfter=No|Translit=nǎ裏|LTranslit=nǎ裏
-4	去	去	VERB	_	_	1	conj	_	SpaceAfter=No|Translit=qù|LTranslit=qù
+3	哪裏	哪裏	PRON	_	_	4	obl	_	SpaceAfter=No|Translit=nǎ裏|LTranslit=nǎ裏|CxnElt=4:Interrogative-WHInfo-Direct.WHWord
+4	去	去	VERB	_	_	1	conj	_	SpaceAfter=No|Translit=qù|LTranslit=qù|Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	了	了	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 6	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -4230,8 +4230,8 @@
 # text = 可以怎樣稱呼我？我只知道整條街都稱我「大家姐」，因為我最大，年紀最大。
 # translit = kěyǐzěnyàngchēnghūwǒ?wǒzhǐzhīdàozhěngtiáojiēdōuchēngwǒ‘dàjiājie’,yīnwèiwǒzuìdà,niánjìzuìdà.
 1	可以	可以	AUX	_	_	3	aux	_	SpaceAfter=No|Translit=kěyǐ|LTranslit=kěyǐ
-2	怎樣	怎樣	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=zěnyàng|LTranslit=zěnyàng
-3	稱呼	稱呼	VERB	_	_	0	root	_	SpaceAfter=No|Translit=chēnghū|LTranslit=chēnghū
+2	怎樣	怎樣	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=zěnyàng|LTranslit=zěnyàng|CxnElt=3:Interrogative-WHInfo-Direct.WHWord
+3	稱呼	稱呼	VERB	_	_	0	root	_	SpaceAfter=No|Translit=chēnghū|LTranslit=chēnghū|Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	我	我	PRON	_	_	3	obj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 5	？	？	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 6	我	我	PRON	_	_	8	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -4342,13 +4342,13 @@
 10	很	很	ADV	_	_	11	advmod	_	SpaceAfter=No|Translit=hěn|LTranslit=hěn
 11	忙	忙	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=máng|LTranslit=máng
 12	，	，	PUNCT	_	_	13	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-13	做	做	VERB	_	_	11	conj	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò
+13	做	做	VERB	_	_	11	conj	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò|Cxn=Resultative|CxnElt=13:Resultative.Event
 14	不	不	ADV	_	_	15	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-15	來	來	VERB	_	_	13	compound:vv	_	SpaceAfter=No|Translit=lái|LTranslit=lái
+15	來	來	VERB	_	_	13	compound:vv	_	SpaceAfter=No|Translit=lái|LTranslit=lái|CxnElt=13:Resultative.ResultState
 16	，	，	PUNCT	_	_	17	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-17	打理	打理	VERB	_	_	11	conj	_	SpaceAfter=No|Translit=dǎlǐ|LTranslit=dǎlǐ
+17	打理	打理	VERB	_	_	11	conj	_	SpaceAfter=No|Translit=dǎlǐ|LTranslit=dǎlǐ|Cxn=Resultative|CxnElt=17:Resultative.Event
 18	不	不	ADV	_	_	19	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-19	了	了	VERB	_	_	17	compound:vv	_	SpaceAfter=No|Translit=le|LTranslit=le
+19	了	了	VERB	_	_	17	compound:vv	_	SpaceAfter=No|Translit=le|LTranslit=le|CxnElt=17:Resultative.ResultState
 20	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 427
@@ -4407,15 +4407,15 @@
 8	打	打	VERB	_	_	18	advcl	_	SpaceAfter=No|Translit=dǎ|LTranslit=dǎ
 9	過	過	AUX	_	_	8	aux	_	SpaceAfter=No|Translit=guò|LTranslit=guò
 10	工	工	NOUN	_	_	8	compound:vo	_	SpaceAfter=No|Translit=gōng|LTranslit=gōng
-11	有	有	VERB	_	_	8	conj	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-12	經驗	經驗	NOUN	_	_	11	obj	_	SpaceAfter=No|Translit=jīngyàn|LTranslit=jīngyàn
+11	有	有	VERB	_	_	8	conj	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+12	經驗	經驗	NOUN	_	_	11	obj	_	SpaceAfter=No|Translit=jīngyàn|LTranslit=jīngyàn|CxnElt=11:Existential-HavePred.Pivot
 13	了	了	PART	_	_	8	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 14	，	，	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 15	自己	自己	PRON	_	_	18	nsubj	_	SpaceAfter=No|Translit=zìjǐ|LTranslit=zìjǐ
 16	就	就	ADV	_	_	18	advmod	_	SpaceAfter=No|Translit=jiù|LTranslit=jiù
 17	能	能	AUX	_	_	18	aux	_	SpaceAfter=No|Translit=néng|LTranslit=néng
-18	做	做	VERB	_	_	1	parataxis	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò
-19	好	好	ADJ	_	_	18	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
+18	做	做	VERB	_	_	1	parataxis	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò|Cxn=Resultative|CxnElt=18:Resultative.Event
+19	好	好	ADJ	_	_	18	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo|CxnElt=18:Resultative.ResultState
 20	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 430
@@ -4434,7 +4434,7 @@
 5	能	能	AUX	_	_	6	aux	_	SpaceAfter=No|Translit=néng|LTranslit=néng
 6	有用	有用	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒuyòng|LTranslit=yǒuyòng
 7	，	，	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-8	對	對	ADJ	_	_	6	parataxis	_	SpaceAfter=No|Translit=duì|LTranslit=duì
+8	對	對	ADJ	_	_	6	parataxis	_	SpaceAfter=No|Translit=duì|LTranslit=duì|Cxn=Interrogative-Polar-Direct|CxnElt=8:Interrogative-Polar-Direct.Clause
 9	嗎	嗎	PART	_	_	8	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 10	？	？	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -4544,8 +4544,8 @@
 15	、	、	PUNCT	_	_	16	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 16	西人	西人	NOUN	_	_	9	conj	_	SpaceAfter=No|Translit=xirén|LTranslit=xirén
 17	，	，	PUNCT	_	_	16	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-18	來	來	VERB	_	_	8	xcomp	_	SpaceAfter=No|Translit=lái|LTranslit=lái
-19	到	到	VERB	_	_	18	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+18	來	來	VERB	_	_	8	xcomp	_	SpaceAfter=No|Translit=lái|LTranslit=lái|Cxn=Resultative|CxnElt=18:Resultative.Event
+19	到	到	VERB	_	_	18	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=18:Resultative.ResultState
 20	捧場	捧場	VERB	_	_	18	conj	_	SpaceAfter=No|Translit=pěngchǎng|LTranslit=pěngchǎng
 21	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
@@ -4628,8 +4628,8 @@
 4	，	，	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 5	不	不	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
 6	就	就	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=jiù|LTranslit=jiù
-7	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-8	電	電	NOUN	_	_	7	obj	_	SpaceAfter=No|Translit=diàn|LTranslit=diàn
+7	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred,Interrogative-Reduced|CxnElt=7:Interrogative-Reduced.Clause
+8	電	電	NOUN	_	_	7	obj	_	SpaceAfter=No|Translit=diàn|LTranslit=diàn|CxnElt=7:Existential-HavePred.Pivot
 9	了	了	PART	_	_	7	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 10	？	？	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -4645,9 +4645,9 @@
 7	體力	體力	NOUN	_	_	8	nsubj	_	SpaceAfter=No|Translit=tǐlì|LTranslit=tǐlì
 8	有限	有限	VERB	_	_	5	conj	_	SpaceAfter=No|Translit=yǒuxiàn|LTranslit=yǒuxiàn
 9	，	，	PUNCT	_	_	10	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-10	拉	拉	VERB	_	_	5	conj	_	SpaceAfter=No|Translit=lā|LTranslit=lā
+10	拉	拉	VERB	_	_	5	conj	_	SpaceAfter=No|Translit=lā|LTranslit=lā|Cxn=Resultative|CxnElt=10:Resultative.Event
 11	不	不	ADV	_	_	12	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-12	動	動	VERB	_	_	10	compound:vv	_	SpaceAfter=No|Translit=dòng|LTranslit=dòng
+12	動	動	VERB	_	_	10	compound:vv	_	SpaceAfter=No|Translit=dòng|LTranslit=dòng|CxnElt=10:Resultative.ResultState
 13	，	，	PUNCT	_	_	14	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 14	找	找	VERB	_	_	5	conj	_	SpaceAfter=No|Translit=zhǎo|LTranslit=zhǎo
 15	人	人	NOUN	_	_	14	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén
@@ -4664,8 +4664,8 @@
 5	，	，	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 6	脾氣	脾氣	NOUN	_	_	8	nsubj	_	SpaceAfter=No|Translit=píqì|LTranslit=píqì
 7	都	都	ADV	_	_	8	advmod	_	SpaceAfter=No|Translit=dōu|LTranslit=dōu
-8	變	變	VERB	_	_	0	root	_	SpaceAfter=No|Translit=biàn|LTranslit=biàn
-9	好	好	ADJ	_	_	8	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
+8	變	變	VERB	_	_	0	root	_	SpaceAfter=No|Translit=biàn|LTranslit=biàn|Cxn=Resultative|CxnElt=8:Resultative.Event
+9	好	好	ADJ	_	_	8	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo|CxnElt=8:Resultative.ResultState
 10	了	了	PART	_	_	8	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 11	！	！	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
@@ -4740,26 +4740,26 @@
 # sent_id = 451
 # text = 有人氣就是有財氣，有財氣就是有福氣，有了福氣就有運氣！
 # translit = yǒurénqìjiùshìyǒucáiqì,yǒucáiqìjiùshìyǒufúqì,yǒulefúqìjiùyǒuyùnqì!
-1	有	有	VERB	_	_	4	csubj	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-2	人氣	人氣	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=rénqì|LTranslit=rénqì
+1	有	有	VERB	_	_	4	csubj	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+2	人氣	人氣	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=rénqì|LTranslit=rénqì|CxnElt=1:Existential-HavePred.Pivot
 3	就	就	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=jiù|LTranslit=jiù
 4	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
-5	有	有	VERB	_	_	4	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-6	財氣	財氣	NOUN	_	_	5	obj	_	SpaceAfter=No|Translit=cáiqì|LTranslit=cáiqì
+5	有	有	VERB	_	_	4	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+6	財氣	財氣	NOUN	_	_	5	obj	_	SpaceAfter=No|Translit=cáiqì|LTranslit=cáiqì|CxnElt=5:Existential-HavePred.Pivot
 7	，	，	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-8	有	有	VERB	_	_	11	csubj	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-9	財氣	財氣	NOUN	_	_	8	obj	_	SpaceAfter=No|Translit=cáiqì|LTranslit=cáiqì
+8	有	有	VERB	_	_	11	csubj	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+9	財氣	財氣	NOUN	_	_	8	obj	_	SpaceAfter=No|Translit=cáiqì|LTranslit=cáiqì|CxnElt=8:Existential-HavePred.Pivot
 10	就	就	ADV	_	_	11	advmod	_	SpaceAfter=No|Translit=jiù|LTranslit=jiù
 11	是	是	VERB	_	_	4	conj	_	SpaceAfter=No|Translit=shì|LTranslit=shì
-12	有	有	VERB	_	_	11	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-13	福氣	福氣	NOUN	_	_	12	obj	_	SpaceAfter=No|Translit=fúqì|LTranslit=fúqì
+12	有	有	VERB	_	_	11	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+13	福氣	福氣	NOUN	_	_	12	obj	_	SpaceAfter=No|Translit=fúqì|LTranslit=fúqì|CxnElt=12:Existential-HavePred.Pivot
 14	，	，	PUNCT	_	_	19	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-15	有	有	VERB	_	_	19	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
+15	有	有	VERB	_	_	19	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
 16	了	了	AUX	_	_	15	aux	_	SpaceAfter=No|Translit=le|LTranslit=le
-17	福氣	福氣	NOUN	_	_	15	obj	_	SpaceAfter=No|Translit=fúqì|LTranslit=fúqì
+17	福氣	福氣	NOUN	_	_	15	obj	_	SpaceAfter=No|Translit=fúqì|LTranslit=fúqì|CxnElt=15:Existential-HavePred.Pivot
 18	就	就	ADV	_	_	19	advmod	_	SpaceAfter=No|Translit=jiù|LTranslit=jiù
-19	有	有	VERB	_	_	4	conj	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-20	運氣	運氣	NOUN	_	_	19	obj	_	SpaceAfter=No|Translit=yùnqì|LTranslit=yùnqì
+19	有	有	VERB	_	_	4	conj	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+20	運氣	運氣	NOUN	_	_	19	obj	_	SpaceAfter=No|Translit=yùnqì|LTranslit=yùnqì|CxnElt=19:Existential-HavePred.Pivot
 21	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 452
@@ -4767,7 +4767,7 @@
 # translit = jiārényǒushuōbùyàokāigēdàngma?
 1	家人	家人	NOUN	_	_	3	nsubj	_	SpaceAfter=No|Translit=jiārén|LTranslit=jiārén
 2	有	有	AUX	_	_	3	aux	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-3	說	說	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shuō|LTranslit=shuō
+3	說	說	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shuō|LTranslit=shuō|Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	不要	要	AUX	_	Polarity=Neg	5	aux	_	SpaceAfter=No|Translit=bùyào|LTranslit=yào
 5	開	開	VERB	_	_	3	ccomp	_	SpaceAfter=No|Translit=kāi|LTranslit=kāi
 6	歌檔	歌檔	NOUN	_	_	5	obj	_	SpaceAfter=No|Translit=gēdàng|LTranslit=gēdàng
@@ -4887,8 +4887,8 @@
 4	幾乎	幾乎	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=jǐhu|LTranslit=jǐhu
 5	天天	天天	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=tiāntiān|LTranslit=tiāntiān
 6	都	都	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=dōu|LTranslit=dōu
-7	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-8	人	人	NOUN	_	_	7	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén
+7	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+8	人	人	NOUN	_	_	7	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén|CxnElt=7:Existential-HavePred.Pivot
 9	唱	唱	VERB	_	_	8	acl	_	SpaceAfter=No|Translit=chàng|LTranslit=chàng
 10	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
@@ -4918,8 +4918,8 @@
 # text = 都有人唱新歌！
 # translit = dōuyǒurénchàngxīngē!
 1	都	都	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=dōu|LTranslit=dōu
-2	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-3	人	人	NOUN	_	_	2	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén
+2	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+3	人	人	NOUN	_	_	2	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén|CxnElt=2:Existential-HavePred.Pivot
 4	唱	唱	VERB	_	_	3	acl	_	SpaceAfter=No|Translit=chàng|LTranslit=chàng
 5	新	新	ADJ	_	_	6	amod	_	SpaceAfter=No|Translit=xīn|LTranslit=xīn
 6	歌	歌	NOUN	_	_	4	obj	_	SpaceAfter=No|Translit=gē|LTranslit=gē
@@ -4945,9 +4945,9 @@
 # translit = nǐyǐqiánzuòguòshénmene?
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 2	以前	以前	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No|Translit=yǐqián|LTranslit=yǐqián
-3	做	做	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò
+3	做	做	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò|Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	過	過	AUX	_	_	3	aux	_	SpaceAfter=No|Translit=guò|LTranslit=guò
-5	什麼	什麼	PRON	_	_	3	obj	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
+5	什麼	什麼	PRON	_	_	3	obj	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=3:Interrogative-WHInfo-Direct.WHWord
 6	呢	呢	PART	_	_	3	discourse:sp	_	SpaceAfter=No|Translit=ne|LTranslit=ne
 7	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -4975,9 +4975,9 @@
 2	時	時	ADP	_	_	1	case	_	SpaceAfter=No|Translit=shí|LTranslit=shí
 3	參賽	參賽	VERB	_	_	0	root	_	SpaceAfter=No|Translit=cānsài|LTranslit=cānsài
 4	，	，	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-5	入	入	VERB	_	_	3	conj	_	SpaceAfter=No|Translit=rù|LTranslit=rù
+5	入	入	VERB	_	_	3	conj	_	SpaceAfter=No|Translit=rù|LTranslit=rù|Cxn=Resultative|CxnElt=5:Resultative.Event
 6	不	不	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-7	到	到	VERB	_	_	5	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+7	到	到	VERB	_	_	5	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=5:Resultative.ResultState
 8	圍	圍	NOUN	_	_	5	compound:vo	_	SpaceAfter=No|Translit=wéi|LTranslit=wéi
 9	呢	呢	PART	_	_	5	discourse:sp	_	SpaceAfter=No|Translit=ne|LTranslit=ne
 10	，	，	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
@@ -4989,7 +4989,7 @@
 # translit = cóngxiǎojiùxǐhuanchànggē?
 1	從小	從小	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=cóngxiǎo|LTranslit=cóngxiǎo
 2	就	就	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=jiù|LTranslit=jiù
-3	喜歡	喜歡	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xǐhuan|LTranslit=xǐhuan
+3	喜歡	喜歡	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xǐhuan|LTranslit=xǐhuan|Cxn=Interrogative-Reduced|CxnElt=3:Interrogative-Reduced.Clause
 4	唱歌	唱歌	VERB	_	_	3	xcomp	_	SpaceAfter=No|Translit=chànggē|LTranslit=chànggē
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -5011,9 +5011,9 @@
 1	但是	但是	CCONJ	_	_	4	cc	_	SpaceAfter=No|Translit=dànshì|LTranslit=dànshì
 2	興趣	興趣	NOUN	_	_	4	obj:periph	_	SpaceAfter=No|Translit=xìngqù|LTranslit=xìngqù
 3	……	……	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
-4	發展	發展	VERB	_	_	0	root	_	SpaceAfter=No|Translit=fāzhǎn|LTranslit=fāzhǎn
+4	發展	發展	VERB	_	_	0	root	_	SpaceAfter=No|Translit=fāzhǎn|LTranslit=fāzhǎn|Cxn=Resultative|CxnElt=4:Resultative.Event
 5	不	不	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-6	了	了	VERB	_	_	4	compound:vv	_	SpaceAfter=No|Translit=le|LTranslit=le
+6	了	了	VERB	_	_	4	compound:vv	_	SpaceAfter=No|Translit=le|LTranslit=le|CxnElt=4:Resultative.ResultState
 7	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 470
@@ -5031,8 +5031,8 @@
 10	這裡	這裡	PRON	_	_	9	obj	_	SpaceAfter=No|Translit=zhèli|LTranslit=zhèli
 11	，	，	PUNCT	_	_	13	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 12	只	只	ADV	_	_	13	advmod	_	SpaceAfter=No|Translit=zhǐ|LTranslit=zhǐ
-13	有	有	VERB	_	_	9	parataxis	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-14	歌廳	歌廳	NOUN	_	_	13	obj	_	SpaceAfter=No|Translit=gētīng|LTranslit=gētīng
+13	有	有	VERB	_	_	9	parataxis	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+14	歌廳	歌廳	NOUN	_	_	13	obj	_	SpaceAfter=No|Translit=gētīng|LTranslit=gētīng|CxnElt=13:Existential-HavePred.Pivot
 15	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 471
@@ -5312,9 +5312,9 @@
 # translit = dāngshíwǒwèishénmehuìrùzhègèxíngyène?
 1	當時	當時	NOUN	_	_	5	obl:tmod	_	SpaceAfter=No|Translit=dāngshí|LTranslit=dāngshí
 2	我	我	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
-3	為什麼	為什麼	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=wèishénme|LTranslit=wèishénme
+3	為什麼	為什麼	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=wèishénme|LTranslit=wèishénme|CxnElt=5:Interrogative-WHInfo-Direct.WHWord
 4	會	會	AUX	_	_	5	aux	_	SpaceAfter=No|Translit=huì|LTranslit=huì
-5	入	入	VERB	_	_	0	root	_	SpaceAfter=No|Translit=rù|LTranslit=rù
+5	入	入	VERB	_	_	0	root	_	SpaceAfter=No|Translit=rù|LTranslit=rù|Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	這	這	DET	_	_	8	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
 7	個	個	NOUN	_	NounType=Clf	6	clf	_	SpaceAfter=No|Translit=gè|LTranslit=gè
 8	行業	行業	NOUN	_	_	5	obj	_	SpaceAfter=No|Translit=xíngyè|LTranslit=xíngyè
@@ -5347,8 +5347,8 @@
 5	香港	香港	PROPN	_	_	3	obl	_	SpaceAfter=No|Translit=xiānggǎng|LTranslit=xiānggǎng
 6	都	都	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=dōu|LTranslit=dōu
 7	希望	希望	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xīwàng|LTranslit=xīwàng
-8	找	找	VERB	_	_	7	ccomp	_	SpaceAfter=No|Translit=zhǎo|LTranslit=zhǎo
-9	到	到	VERB	_	_	8	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+8	找	找	VERB	_	_	7	ccomp	_	SpaceAfter=No|Translit=zhǎo|LTranslit=zhǎo|Cxn=Resultative|CxnElt=8:Resultative.Event
+9	到	到	VERB	_	_	8	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=8:Resultative.ResultState
 10	我	我	PRON	_	_	11	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 11	喜歡	喜歡	VERB	_	_	13	acl	_	SpaceAfter=No|Translit=xǐhuan|LTranslit=xǐhuan
 12	的	的	PART	_	_	11	mark:rel	_	SpaceAfter=No|Translit=de|LTranslit=de
@@ -5376,9 +5376,9 @@
 # text = 終於有個朋友介紹我在酒樓夜總會唱歌。
 # translit = zhōngyúyǒugèpéngyoujièshàowǒzàijiǔlóuyèzǒnghuìchànggē.
 1	終於	終於	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zhōngyú|LTranslit=zhōngyú
-2	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
+2	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
 3	個	個	NOUN	_	NounType=Clf	4	clf	_	SpaceAfter=No|Translit=gè|LTranslit=gè
-4	朋友	朋友	NOUN	_	_	2	obj	_	SpaceAfter=No|Translit=péngyou|LTranslit=péngyou
+4	朋友	朋友	NOUN	_	_	2	obj	_	SpaceAfter=No|Translit=péngyou|LTranslit=péngyou|CxnElt=2:Existential-HavePred.Pivot
 5	介紹	介紹	VERB	_	_	4	acl	_	SpaceAfter=No|Translit=jièshào|LTranslit=jièshào
 6	我	我	PRON	_	_	5	obj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 7	在	在	ADP	_	_	9	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -5409,8 +5409,8 @@
 17	「	「	PUNCT	_	_	20	punct	_	SpaceAfter=No|Translit=‘|LTranslit=‘
 18	廟街	廟街	PROPN	_	_	20	obl	_	SpaceAfter=No|Translit=miàojiē|LTranslit=miàojiē
 19	都	都	ADV	_	_	20	advmod	_	SpaceAfter=No|Translit=dōu|LTranslit=dōu
-20	有	有	VERB	_	_	15	parataxis	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-21	歌	歌	NOUN	_	_	20	obj	_	SpaceAfter=No|Translit=gē|LTranslit=gē
+20	有	有	VERB	_	_	15	parataxis	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+21	歌	歌	NOUN	_	_	20	obj	_	SpaceAfter=No|Translit=gē|LTranslit=gē|CxnElt=20:Existential-HavePred.Pivot
 22	唱	唱	VERB	_	_	21	acl	_	SpaceAfter=No|Translit=chàng|LTranslit=chàng
 23	，	，	PUNCT	_	_	28	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 24	但	但	CCONJ	_	_	28	cc	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -5485,8 +5485,8 @@
 14	能	能	AUX	_	_	17	aux	_	SpaceAfter=No|Translit=néng|LTranslit=néng
 15	不	不	ADV	_	_	17	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
 16	能	能	AUX	_	_	17	aux	_	SpaceAfter=No|Translit=néng|LTranslit=néng
-17	接受	接受	VERB	_	_	12	ccomp	_	SpaceAfter=No|Translit=jiēshòu|LTranslit=jiēshòu
-18	到	到	VERB	_	_	17	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+17	接受	接受	VERB	_	_	12	ccomp	_	SpaceAfter=No|Translit=jiēshòu|LTranslit=jiēshòu|Cxn=Resultative|CxnElt=17:Resultative.Event
+18	到	到	VERB	_	_	17	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=17:Resultative.ResultState
 19	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 496
@@ -5503,8 +5503,8 @@
 9	舞台	舞台	NOUN	_	_	10	obl	_	SpaceAfter=No|Translit=wǔtái|LTranslit=wǔtái
 10	唱歌	唱歌	VERB	_	_	5	ccomp	_	SpaceAfter=No|Translit=chànggē|LTranslit=chànggē
 11	，	，	PUNCT	_	_	16	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-12	唱	唱	VERB	_	_	16	advcl	_	SpaceAfter=No|Translit=chàng|LTranslit=chàng
-13	完	完	VERB	_	_	12	compound:vv	_	SpaceAfter=No|Translit=wán|LTranslit=wán
+12	唱	唱	VERB	_	_	16	advcl	_	SpaceAfter=No|Translit=chàng|LTranslit=chàng|Cxn=Resultative|CxnElt=12:Resultative.Event
+13	完	完	VERB	_	_	12	compound:vv	_	SpaceAfter=No|Translit=wán|LTranslit=wán|CxnElt=12:Resultative.ResultState
 14	歌	歌	NOUN	_	_	12	compound:vo	_	SpaceAfter=No|Translit=gē|LTranslit=gē
 15	就	就	ADV	_	_	16	advmod	_	SpaceAfter=No|Translit=jiù|LTranslit=jiù
 16	走	走	VERB	_	_	5	parataxis	_	SpaceAfter=No|Translit=zǒu|LTranslit=zǒu
@@ -5728,8 +5728,8 @@
 6	，	，	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 7	和	和	ADP	_	_	8	case	_	SpaceAfter=No|Translit=hé|LTranslit=hé
 8	子女	子女	NOUN	_	_	9	obl	_	SpaceAfter=No|Translit=zinǚ|LTranslit=zinǚ
-9	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-10	什麼	什麼	PRON	_	_	9	obj	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
+9	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Interrogative-WHInfo-Direct|CxnElt=9:Interrogative-WHInfo-Direct.Clause
+10	什麼	什麼	PRON	_	_	9	obj	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=9:Interrogative-WHInfo-Direct.WHWord
 11	好	好	VERB	_	_	10	acl	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
 12	談	談	VERB	_	_	11	xcomp	_	SpaceAfter=No|Translit=tán|LTranslit=tán
 13	呢	呢	PART	_	_	9	discourse:sp	_	SpaceAfter=No|Translit=ne|LTranslit=ne
@@ -5749,8 +5749,8 @@
 9	的	的	PART	_	_	8	case	_	SpaceAfter=No|Translit=de|LTranslit=de
 10	老豆	老豆	NOUN	_	_	12	obl	_	SpaceAfter=No|Translit=lǎodòu|LTranslit=lǎodòu
 11	老母	老母	NOUN	_	_	10	conj	_	SpaceAfter=No|Translit=lǎomǔ|LTranslit=lǎomǔ
-12	有	有	VERB	_	_	4	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-13	什麼	什麼	PRON	_	_	12	obj	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
+12	有	有	VERB	_	_	4	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Interrogative-WHInfo-Direct|CxnElt=12:Interrogative-WHInfo-Direct.Clause
+13	什麼	什麼	PRON	_	_	12	obj	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=12:Interrogative-WHInfo-Direct.WHWord
 14	好	好	VERB	_	_	13	acl	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
 15	談	談	VERB	_	_	14	xcomp	_	SpaceAfter=No|Translit=tán|LTranslit=tán
 16	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -5765,7 +5765,7 @@
 5	吵架	吵架	VERB	_	_	0	root	_	SpaceAfter=No|Translit=chǎojià|LTranslit=chǎojià
 6	了	了	PART	_	_	5	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 7	，	，	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-8	對	對	ADJ	_	_	5	parataxis	_	SpaceAfter=No|Translit=duì|LTranslit=duì
+8	對	對	ADJ	_	_	5	parataxis	_	SpaceAfter=No|Translit=duì|LTranslit=duì|Cxn=Interrogative-Polar-Direct|CxnElt=8:Interrogative-Polar-Direct.Clause
 9	嗎	嗎	PART	_	_	8	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 10	？	？	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -5829,7 +5829,7 @@
 8	廟街	廟街	PROPN	_	_	11	nsubj	_	SpaceAfter=No|Translit=miàojiē|LTranslit=miàojiē
 9	跟	跟	ADP	_	_	10	case	_	SpaceAfter=No|Translit=gēn|LTranslit=gēn
 10	現在	現在	NOUN	_	_	11	obl	_	SpaceAfter=No|Translit=xiànzài|LTranslit=xiànzài
-11	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
+11	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Interrogative-Polar-Direct|CxnElt=11:Interrogative-Polar-Direct.Clause
 12	分別	分別	NOUN	_	_	11	obj	_	SpaceAfter=No|Translit=fēnbié|LTranslit=fēnbié
 13	嗎	嗎	PART	_	_	11	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 14	？	？	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -5977,9 +5977,9 @@
 # text = 都有三十年了。
 # translit = dōuyǒusānshíniánle.
 1	都	都	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=dōu|LTranslit=dōu
-2	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
+2	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
 3	三十	三十	NUM	_	_	4	nummod	_	SpaceAfter=No|Translit=sānshí|LTranslit=sānshí
-4	年	年	NOUN	_	NounType=Clf	2	obj	_	SpaceAfter=No|Translit=nián|LTranslit=nián
+4	年	年	NOUN	_	NounType=Clf	2	obj	_	SpaceAfter=No|Translit=nián|LTranslit=nián|CxnElt=2:Existential-HavePred.Pivot
 5	了	了	PART	_	_	2	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 6	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
@@ -6076,8 +6076,8 @@
 6	，	，	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 7	欄杆	欄杆	NOUN	_	_	9	obl	_	SpaceAfter=No|Translit=lángān|LTranslit=lángān
 8	那邊	那邊	PRON	_	_	7	appos	_	SpaceAfter=No|Translit=nàbiān|LTranslit=nàbiān
-9	圍	圍	VERB	_	_	4	parataxis	_	SpaceAfter=No|Translit=wéi|LTranslit=wéi
-10	滿	滿	ADJ	_	_	9	compound:vv	_	SpaceAfter=No|Translit=mǎn|LTranslit=mǎn
+9	圍	圍	VERB	_	_	4	parataxis	_	SpaceAfter=No|Translit=wéi|LTranslit=wéi|Cxn=Resultative|CxnElt=9:Resultative.Event
+10	滿	滿	ADJ	_	_	9	compound:vv	_	SpaceAfter=No|Translit=mǎn|LTranslit=mǎn|CxnElt=9:Resultative.ResultState
 11	人	人	NOUN	_	_	9	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén
 12	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
@@ -6094,8 +6094,8 @@
 8	五百	五百	NUM	_	_	9	nummod	_	SpaceAfter=No|Translit=wǔbǎi|LTranslit=wǔbǎi
 9	元	元	NOUN	_	NounType=Clf	10	compound	_	SpaceAfter=No|Translit=yuán|LTranslit=yuán
 10	鈔票	鈔票	NOUN	_	_	11	obl	_	SpaceAfter=No|Translit=chāopiào|LTranslit=chāopiào
-11	摺	摺	VERB	_	_	0	root	_	SpaceAfter=No|Translit=摺|LTranslit=摺
-12	成	成	VERB	_	_	11	compound:vv	_	SpaceAfter=No|Translit=chéng|LTranslit=chéng
+11	摺	摺	VERB	_	_	0	root	_	SpaceAfter=No|Translit=摺|LTranslit=摺|Cxn=Resultative|CxnElt=11:Resultative.Event
+12	成	成	VERB	_	_	11	compound:vv	_	SpaceAfter=No|Translit=chéng|LTranslit=chéng|CxnElt=11:Resultative.ResultState
 13	紙飛機	紙飛機	NOUN	_	_	12	obj	_	SpaceAfter=No|Translit=zhǐfēijī|LTranslit=zhǐfēijī
 14	飛	飛	VERB	_	_	11	conj	_	SpaceAfter=No|Translit=fēi|LTranslit=fēi
 15	過來	過來	VERB	_	_	14	compound:dir	_	SpaceAfter=No|Translit=guòlái|LTranslit=guòlái
@@ -6169,8 +6169,8 @@
 6	，	，	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 7	還	還	ADV	_	_	9	advmod	_	SpaceAfter=No|Translit=hái|LTranslit=hái
 8	未	未	ADV	_	_	9	advmod	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
-9	有	有	VERB	_	_	3	conj	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-10	知名度	知名度	NOUN	_	_	9	obj	_	SpaceAfter=No|Translit=zhīmíngdù|LTranslit=zhīmíngdù
+9	有	有	VERB	_	_	3	conj	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+10	知名度	知名度	NOUN	_	_	9	obj	_	SpaceAfter=No|Translit=zhīmíngdù|LTranslit=zhīmíngdù|CxnElt=9:Existential-HavePred.Pivot
 11	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 538
@@ -6214,10 +6214,10 @@
 # translit = xiànzàishìzěnyàngle?jiéshùlema?
 1	現在	現在	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No|Translit=xiànzài|LTranslit=xiànzài
 2	是	是	AUX	_	_	3	cop	_	SpaceAfter=No|Translit=shì|LTranslit=shì
-3	怎樣	怎樣	PRON	_	_	0	root	_	SpaceAfter=No|Translit=zěnyàng|LTranslit=zěnyàng
+3	怎樣	怎樣	PRON	_	_	0	root	_	SpaceAfter=No|Translit=zěnyàng|LTranslit=zěnyàng|Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause,3:Interrogative-WHInfo-Direct.WHWord
 4	了	了	PART	_	_	3	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 5	？	？	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
-6	結束	結束	VERB	_	_	3	parataxis	_	SpaceAfter=No|Translit=jiéshù|LTranslit=jiéshù
+6	結束	結束	VERB	_	_	3	parataxis	_	SpaceAfter=No|Translit=jiéshù|LTranslit=jiéshù|Cxn=Interrogative-Polar-Direct|CxnElt=6:Interrogative-Polar-Direct.Clause
 7	了	了	PART	_	_	6	discourse:sp	_	SpaceAfter=No|Translit=le|LTranslit=le
 8	嗎	嗎	PART	_	_	6	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 9	？	？	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -6291,13 +6291,13 @@
 1	因為	因為	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
 2	有時候	有時候	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=yǒushíhou|LTranslit=yǒushíhou
 3	會	會	AUX	_	_	4	aux	_	SpaceAfter=No|Translit=huì|LTranslit=huì
-4	有	有	VERB	_	_	17	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-5	人	人	NOUN	_	_	4	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén
+4	有	有	VERB	_	_	17	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+5	人	人	NOUN	_	_	4	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén|CxnElt=4:Existential-HavePred.Pivot
 6	投訴	投訴	VERB	_	_	5	acl	_	SpaceAfter=No|Translit=tóusu|LTranslit=tóusu
 7	，	，	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 8	說	說	VERB	_	_	6	ccomp	_	SpaceAfter=No|Translit=shuō|LTranslit=shuō
-9	有	有	VERB	_	_	8	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-10	噪音	噪音	NOUN	_	_	9	obj	_	SpaceAfter=No|Translit=zàoyīn|LTranslit=zàoyīn
+9	有	有	VERB	_	_	8	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+10	噪音	噪音	NOUN	_	_	9	obj	_	SpaceAfter=No|Translit=zàoyīn|LTranslit=zàoyīn|CxnElt=9:Existential-HavePred.Pivot
 11	，	，	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 12	所以	所以	ADV	_	_	17	advmod	_	SpaceAfter=No|Translit=suǒyǐ|LTranslit=suǒyǐ
 13	我們	我	PRON	_	_	17	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
@@ -6324,7 +6324,7 @@
 3	的	的	PART	_	_	1	case	_	SpaceAfter=No|Gloss=NOM|Translit=de|LTranslit=de
 4	是	是	AUX	_	_	6	cop	_	SpaceAfter=No|Gloss=COP|Translit=shì|LTranslit=shì
 5	這	這	DET	_	_	6	det	_	SpaceAfter=No|Gloss=this|Translit=zhè|LTranslit=zhè
-6	個	個	NOUN	_	NounType=Clf	0	root	_	SpaceAfter=No|Gloss=CLF.GEN|Translit=gè|LTranslit=gè
+6	個	個	NOUN	_	NounType=Clf	0	root	_	SpaceAfter=No|Gloss=CLF.GEN|Translit=gè|LTranslit=gè|Cxn=Interrogative-Polar-Direct|CxnElt=6:Interrogative-Polar-Direct.Clause
 7	嗎	嗎	PART	_	_	6	discourse:sp	_	SpaceAfter=No|Gloss=Q|Translit=ma|LTranslit=ma
 8	……	……	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
@@ -6399,9 +6399,9 @@
 # text = 你為什麼沒空陪我呢？
 # translit = nǐwèishénmeméikōngpéiwǒne?
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-2	為什麼	為什麼	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=wèishénme|LTranslit=wèishénme
+2	為什麼	為什麼	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=wèishénme|LTranslit=wèishénme|CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 3	沒空	空	VERB	_	Polarity=Neg	4	advcl	_	SpaceAfter=No|Translit=méikōng|LTranslit=kōng
-4	陪	陪	VERB	_	_	0	root	_	SpaceAfter=No|Translit=péi|LTranslit=péi
+4	陪	陪	VERB	_	_	0	root	_	SpaceAfter=No|Translit=péi|LTranslit=péi|Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	我	我	PRON	_	_	4	obj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 6	呢	呢	PART	_	_	4	discourse:sp	_	SpaceAfter=No|Translit=ne|LTranslit=ne
 7	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -6558,9 +6558,9 @@
 # sent_id = 570
 # text = 為什麼你沒空呢？
 # translit = wèishénmenǐméikōngne?
-1	為什麼	為什麼	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=wèishénme|LTranslit=wèishénme
+1	為什麼	為什麼	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=wèishénme|LTranslit=wèishénme|CxnElt=3:Interrogative-WHInfo-Direct.WHWord
 2	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-3	沒空	空	VERB	_	Polarity=Neg	0	root	_	SpaceAfter=No|Translit=méikōng|LTranslit=kōng
+3	沒空	空	VERB	_	Polarity=Neg	0	root	_	SpaceAfter=No|Translit=méikōng|LTranslit=kōng|Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	呢	呢	PART	_	_	3	discourse:sp	_	SpaceAfter=No|Translit=ne|LTranslit=ne
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -6576,8 +6576,8 @@
 # text = 你為什麼沒空？
 # translit = nǐwèishénmeméikōng?
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-2	為什麼	為什麼	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=wèishénme|LTranslit=wèishénme
-3	沒空	空	VERB	_	Polarity=Neg	0	root	_	SpaceAfter=No|Translit=méikōng|LTranslit=kōng
+2	為什麼	為什麼	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=wèishénme|LTranslit=wèishénme|CxnElt=3:Interrogative-WHInfo-Direct.WHWord
+3	沒空	空	VERB	_	Polarity=Neg	0	root	_	SpaceAfter=No|Translit=méikōng|LTranslit=kōng|Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 573
@@ -6779,7 +6779,7 @@
 # translit = jīntiānshìxīngqīsānma?
 1	今天	今天	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No|Translit=jīntiān|LTranslit=jīntiān
 2	是	是	AUX	_	_	3	aux	_	SpaceAfter=No|Translit=shì|LTranslit=shì
-3	星期三	星期三	NOUN	_	_	0	root	_	SpaceAfter=No|Translit=xīngqīsān|LTranslit=xīngqīsān
+3	星期三	星期三	NOUN	_	_	0	root	_	SpaceAfter=No|Translit=xīngqīsān|LTranslit=xīngqīsān|Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	嗎	嗎	PART	_	_	3	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -6832,7 +6832,7 @@
 8	「	「	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=‘|LTranslit=‘
 9	你	你	PRON	_	_	11	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 10	明天	明天	NOUN	_	_	11	obl:tmod	_	SpaceAfter=No|Translit=míngtiān|LTranslit=míngtiān
-11	去	去	VERB	_	_	5	parataxis	_	SpaceAfter=No|Translit=qù|LTranslit=qù
+11	去	去	VERB	_	_	5	parataxis	_	SpaceAfter=No|Translit=qù|LTranslit=qù|Cxn=Interrogative-Polar-Direct|CxnElt=11:Interrogative-Polar-Direct.Clause
 12	旅行	旅行	NOUN	_	_	11	obj	_	SpaceAfter=No|Translit=lǚxíng|LTranslit=lǚxíng
 13	嗎	嗎	PART	_	_	11	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 14	？	？	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -6856,8 +6856,8 @@
 1	「	「	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=‘|LTranslit=‘
 2	那	那	ADV	_	_	6	discourse	_	SpaceAfter=No|Translit=nà|LTranslit=nà
 3	你	你	PRON	_	_	6	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-4	甚麼	甚麼	DET	_	_	5	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
-5	時候	時候	NOUN	_	_	6	obl:tmod	_	SpaceAfter=No|Translit=shíhou|LTranslit=shíhou
+4	甚麼	甚麼	DET	_	_	5	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=5:Interrogative-WHInfo-Direct.WHWord
+5	時候	時候	NOUN	_	_	6	obl:tmod	_	SpaceAfter=No|Translit=shíhou|LTranslit=shíhou|Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	回來	回來	VERB	_	_	0	root	_	SpaceAfter=No|Translit=huílái|LTranslit=huílái
 7	呀	呀	PART	_	_	6	discourse:sp	_	SpaceAfter=No|Translit=ya|LTranslit=ya
 8	？	？	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -6891,8 +6891,8 @@
 4	「	「	PUNCT	_	_	10	punct	_	SpaceAfter=No|Translit=‘|LTranslit=‘
 5	那	那	ADV	_	_	10	discourse	_	SpaceAfter=No|Translit=nà|LTranslit=nà
 6	你	你	PRON	_	_	10	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-7	甚麼	甚麼	DET	_	_	8	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
-8	時候	時候	NOUN	_	_	10	obl:tmod	_	SpaceAfter=No|Translit=shíhou|LTranslit=shíhou
+7	甚麼	甚麼	DET	_	_	8	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=8:Interrogative-WHInfo-Direct.WHWord
+8	時候	時候	NOUN	_	_	10	obl:tmod	_	SpaceAfter=No|Translit=shíhou|LTranslit=shíhou|Cxn=Interrogative-WHInfo-Direct|CxnElt=8:Interrogative-WHInfo-Direct.Clause
 9	會	會	AUX	_	_	10	aux	_	SpaceAfter=No|Translit=huì|LTranslit=huì
 10	回來	回來	VERB	_	_	2	parataxis	_	SpaceAfter=No|Translit=huílái|LTranslit=huílái
 11	？	？	PUNCT	_	_	10	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -6945,17 +6945,17 @@
 # sent_id = 607
 # text = 有甚麼事？
 # translit = yǒushénmeshì?
-1	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-2	甚麼	甚麼	DET	_	_	3	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
-3	事	事	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+1	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+2	甚麼	甚麼	DET	_	_	3	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=3:Interrogative-WHInfo-Direct.WHWord
+3	事	事	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Existential-HavePred.Pivot,3:Interrogative-WHInfo-Direct.Clause
 4	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 608
 # text = 為什麼這樣問？
 # translit = wèishénmezhèyàngwèn?
-1	為什麼	為什麼	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=wèishénme|LTranslit=wèishénme
+1	為什麼	為什麼	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=wèishénme|LTranslit=wèishénme|CxnElt=3:Interrogative-WHInfo-Direct.WHWord
 2	這樣	這樣	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=zhèyàng|LTranslit=zhèyàng
-3	問	問	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wèn|LTranslit=wèn
+3	問	問	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wèn|LTranslit=wèn|Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 609
@@ -7009,7 +7009,7 @@
 # translit = 'āiyě,shìma?
 1	哎也	哎也	INTJ	_	_	3	discourse:sp	_	SpaceAfter=No|Translit='āiyě|LTranslit='āiyě
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-3	是	是	AUX	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+3	是	是	AUX	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	嗎	嗎	PART	_	_	3	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -7020,7 +7020,7 @@
 2	的	的	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=de|LTranslit=de
 3	，	，	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 4	有	有	AUX	_	_	5	aux	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-5	量	量	VERB	_	_	1	parataxis	_	SpaceAfter=No|Translit=liàng|LTranslit=liàng
+5	量	量	VERB	_	_	1	parataxis	_	SpaceAfter=No|Translit=liàng|LTranslit=liàng|Cxn=Interrogative-Polar-Direct|CxnElt=5:Interrogative-Polar-Direct.Clause
 6	血壓	血壓	NOUN	_	_	5	obj	_	SpaceAfter=No|Translit=xuèyā|LTranslit=xuèyā
 7	嗎	嗎	PART	_	_	5	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 8	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -7091,15 +7091,15 @@
 # sent_id = 623
 # text = 誰玩樂器？
 # translit = shuíwánlèqì?
-1	誰	誰	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=shuí|LTranslit=shuí
-2	玩	玩	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wán|LTranslit=wán
+1	誰	誰	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=shuí|LTranslit=shuí|CxnElt=2:Interrogative-WHInfo-Direct.WHWord
+2	玩	玩	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wán|LTranslit=wán|Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
 3	樂器	樂器	NOUN	_	_	2	obj	_	SpaceAfter=No|Translit=lèqì|LTranslit=lèqì
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 624
 # text = 卡啦ＯＫ嗎？
 # translit = kǎlaOKma?
-1	卡啦ＯＫ	卡啦ＯＫ	NOUN	_	_	0	root	_	SpaceAfter=No|Translit=kǎlaOK|LTranslit=kǎlaOK
+1	卡啦ＯＫ	卡啦ＯＫ	NOUN	_	_	0	root	_	SpaceAfter=No|Translit=kǎlaOK|LTranslit=kǎlaOK|Cxn=Interrogative-Polar-Direct|CxnElt=1:Interrogative-Polar-Direct.Clause
 2	嗎	嗎	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -7165,7 +7165,7 @@
 # text = 三十乘三十吧？
 # translit = sānshíchéngsānshíba?
 1	三十	三十	NUM	_	_	2	nummod	_	SpaceAfter=No|Translit=sānshí|LTranslit=sānshí
-2	乘	乘	VERB	_	_	0	root	_	SpaceAfter=No|Translit=chéng|LTranslit=chéng
+2	乘	乘	VERB	_	_	0	root	_	SpaceAfter=No|Translit=chéng|LTranslit=chéng|Cxn=Interrogative-Reduced|CxnElt=2:Interrogative-Reduced.Clause
 3	三十	三十	NUM	_	_	2	nummod	_	SpaceAfter=No|Translit=sānshí|LTranslit=sānshí
 4	吧	吧	PART	_	_	2	discourse:sp	_	SpaceAfter=No|Translit=ba|LTranslit=ba
 5	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -7181,7 +7181,7 @@
 # text = 那個呢？
 # translit = nàgène?
 1	那	那	DET	_	_	2	det	_	SpaceAfter=No|Translit=nà|LTranslit=nà
-2	個	個	NOUN	_	NounType=Clf	0	root	_	SpaceAfter=No|Translit=gè|LTranslit=gè
+2	個	個	NOUN	_	NounType=Clf	0	root	_	SpaceAfter=No|Translit=gè|LTranslit=gè|Cxn=Interrogative-Reduced|CxnElt=2:Interrogative-Reduced.Clause
 3	呢	呢	PART	_	_	2	discourse:sp	_	SpaceAfter=No|Translit=ne|LTranslit=ne
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -7200,15 +7200,15 @@
 2	了	了	AUX	_	_	1	aux	_	SpaceAfter=No|Translit=le|LTranslit=le
 3	你	你	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 4	要	要	AUX	_	_	5	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
-5	量	量	VERB	_	_	1	ccomp	_	SpaceAfter=No|Translit=liàng|LTranslit=liàng
-6	好	好	ADJ	_	_	5	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
+5	量	量	VERB	_	_	1	ccomp	_	SpaceAfter=No|Translit=liàng|LTranslit=liàng|Cxn=Resultative|CxnElt=5:Resultative.Event
+6	好	好	ADJ	_	_	5	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo|CxnElt=5:Resultative.ResultState
 7	尺寸	尺寸	NOUN	_	_	5	obj	_	SpaceAfter=No|Translit=chǐcùn|LTranslit=chǐcùn
 8	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 635
 # text = 這樣？
 # translit = zhèyàng?
-1	這樣	這樣	PRON	_	_	0	root	_	SpaceAfter=No|Translit=zhèyàng|LTranslit=zhèyàng
+1	這樣	這樣	PRON	_	_	0	root	_	SpaceAfter=No|Translit=zhèyàng|LTranslit=zhèyàng|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 636
@@ -7237,8 +7237,8 @@
 # text = 小心弄破了！
 # translit = xiǎoxīnnòngpòle!
 1	小心	小心	VERB	_	_	2	advcl	_	SpaceAfter=No|Translit=xiǎoxīn|LTranslit=xiǎoxīn
-2	弄	弄	VERB	_	_	0	root	_	SpaceAfter=No|Translit=nòng|LTranslit=nòng
-3	破	破	VERB	_	_	2	compound:vv	_	SpaceAfter=No|Translit=pò|LTranslit=pò
+2	弄	弄	VERB	_	_	0	root	_	SpaceAfter=No|Translit=nòng|LTranslit=nòng|Cxn=Resultative|CxnElt=2:Resultative.Event
+3	破	破	VERB	_	_	2	compound:vv	_	SpaceAfter=No|Translit=pò|LTranslit=pò|CxnElt=2:Resultative.ResultState
 4	了	了	AUX	_	_	3	aux	_	SpaceAfter=No|Translit=le|LTranslit=le
 5	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
@@ -7249,22 +7249,22 @@
 2	Wong	Wong	PROPN	_	_	1	flat	_	SpaceAfter=No|Translit=Wong|LTranslit=Wong
 3	……	……	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 4	又	又	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=yòu|LTranslit=yòu
-5	吃	吃	VERB	_	_	0	root	_	SpaceAfter=No|Translit=chī|LTranslit=chī
+5	吃	吃	VERB	_	_	0	root	_	SpaceAfter=No|Translit=chī|LTranslit=chī|Cxn=Resultative|CxnElt=5:Resultative.Event
 6	這麼	這麼	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=zhème|LTranslit=zhème
-7	多	多	ADJ	_	_	5	compound:vv	_	SpaceAfter=No|Translit=duō|LTranslit=duō
+7	多	多	ADJ	_	_	5	compound:vv	_	SpaceAfter=No|Translit=duō|LTranslit=duō|CxnElt=5:Resultative.ResultState
 8	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 640
 # text = 胖死你呀，吃這麼多！
 # translit = pàngsǐnǐya,chīzhèmeduō!
-1	胖	胖	VERB	_	_	0	root	_	SpaceAfter=No|Translit=pàng|LTranslit=pàng
-2	死	死	VERB	_	_	1	compound:vv	_	SpaceAfter=No|Translit=sǐ|LTranslit=sǐ
+1	胖	胖	VERB	_	_	0	root	_	SpaceAfter=No|Translit=pàng|LTranslit=pàng|Cxn=Resultative|CxnElt=1:Resultative.Event
+2	死	死	VERB	_	_	1	compound:vv	_	SpaceAfter=No|Translit=sǐ|LTranslit=sǐ|CxnElt=1:Resultative.ResultState
 3	你	你	PRON	_	_	1	obj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 4	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No|Translit=ya|LTranslit=ya
 5	，	，	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-6	吃	吃	VERB	_	_	1	parataxis	_	SpaceAfter=No|Translit=chī|LTranslit=chī
+6	吃	吃	VERB	_	_	1	parataxis	_	SpaceAfter=No|Translit=chī|LTranslit=chī|Cxn=Resultative|CxnElt=6:Resultative.Event
 7	這麼	這麼	ADV	_	_	8	advmod	_	SpaceAfter=No|Translit=zhème|LTranslit=zhème
-8	多	多	ADJ	_	_	6	compound:vv	_	SpaceAfter=No|Translit=duō|LTranslit=duō
+8	多	多	ADJ	_	_	6	compound:vv	_	SpaceAfter=No|Translit=duō|LTranslit=duō|CxnElt=6:Resultative.ResultState
 9	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 641
@@ -7336,8 +7336,8 @@
 # text = 又曬黑番黎喇，哈哈！
 # translit = yòu曬hēifānlílǎ,hāhā!
 1	又	又	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=yòu|LTranslit=yòu
-2	曬	曬	VERB	_	_	0	root	_	SpaceAfter=No|Translit=曬|LTranslit=曬
-3	黑	黑	ADJ	_	_	2	compound:vv	_	SpaceAfter=No|Translit=hēi|LTranslit=hēi
+2	曬	曬	VERB	_	_	0	root	_	SpaceAfter=No|Translit=曬|LTranslit=曬|Cxn=Resultative|CxnElt=2:Resultative.Event
+3	黑	黑	ADJ	_	_	2	compound:vv	_	SpaceAfter=No|Translit=hēi|LTranslit=hēi|CxnElt=2:Resultative.ResultState
 4	番黎	番黎	NOUN	_	_	2	compound:dir	_	SpaceAfter=No|Translit=fānlí|LTranslit=fānlí
 5	喇	喇	PART	_	_	2	discourse:sp	_	SpaceAfter=No|Translit=lǎ|LTranslit=lǎ
 6	，	，	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
@@ -7349,7 +7349,7 @@
 # translit = yǒuwúxiǎngniànwǒne?
 1	有	有	AUX	_	_	3	aux	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
 2	無	無	PART	_	Polarity=Neg	3	advmod	_	SpaceAfter=No|Translit=wú|LTranslit=wú
-3	想念	想念	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xiǎngniàn|LTranslit=xiǎngniàn
+3	想念	想念	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xiǎngniàn|LTranslit=xiǎngniàn|Cxn=Interrogative-Reduced|CxnElt=3:Interrogative-Reduced.Clause
 4	我	我	PRON	_	_	3	obj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 5	呢	呢	PART	_	_	3	discourse:sp	_	SpaceAfter=No|Translit=ne|LTranslit=ne
 6	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -7463,17 +7463,17 @@
 # translit = wǒzhīdàoyǒutóngshìduìzhǔxíhouxuǎnréndeguójíwèntíyǒuxiēyìjiàn.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 2	知道	知道	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhīdào|LTranslit=zhīdào
-3	有	有	VERB	_	_	2	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-4	同事	同事	NOUN	_	_	3	obj	_	SpaceAfter=No|Translit=tóngshì|LTranslit=tóngshì
+3	有	有	VERB	_	_	2	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+4	同事	同事	NOUN	_	_	3	obj	_	SpaceAfter=No|Translit=tóngshì|LTranslit=tóngshì|CxnElt=3:Existential-HavePred.Pivot
 5	對	對	ADP	_	_	10	case	_	SpaceAfter=No|Translit=duì|LTranslit=duì
 6	主席	主席	NOUN	_	_	7	compound	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
 7	候選人	候選人	NOUN	_	_	10	nmod	_	SpaceAfter=No|Translit=houxuǎnrén|LTranslit=houxuǎnrén
 8	的	的	PART	_	_	7	case	_	SpaceAfter=No|Translit=de|LTranslit=de
 9	國籍	國籍	NOUN	_	_	10	compound	_	SpaceAfter=No|Translit=guójí|LTranslit=guójí
 10	問題	問題	NOUN	_	_	11	obl	_	SpaceAfter=No|Translit=wèntí|LTranslit=wèntí
-11	有	有	ADV	_	_	4	acl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
+11	有	有	ADV	_	_	4	acl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
 12	些	些	NOUN	_	NounType=Clf	11	clf	_	SpaceAfter=No|Translit=xiē|LTranslit=xiē
-13	意見	意見	NOUN	_	_	11	obj	_	SpaceAfter=No|Translit=yìjiàn|LTranslit=yìjiàn
+13	意見	意見	NOUN	_	_	11	obj	_	SpaceAfter=No|Translit=yìjiàn|LTranslit=yìjiàn|CxnElt=11:Existential-HavePred.Pivot
 14	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 657
@@ -7742,8 +7742,8 @@
 2	我們	我	PRON	_	_	1	obj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
 3	今天	今天	NOUN	_	_	8	obl:tmod	_	SpaceAfter=No|Translit=jīntiān|LTranslit=jīntiān
 4	可以	可以	AUX	_	_	8	ccomp	_	SpaceAfter=No|Translit=kěyǐ|LTranslit=kěyǐ
-5	有	有	VERB	_	_	8	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-6	秩序	秩序	NOUN	_	_	5	obj	_	SpaceAfter=No|Translit=zhìxù|LTranslit=zhìxù
+5	有	有	VERB	_	_	8	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+6	秩序	秩序	NOUN	_	_	5	obj	_	SpaceAfter=No|Translit=zhìxù|LTranslit=zhìxù|CxnElt=5:Existential-HavePred.Pivot
 7	地	地	PART	_	_	5	mark	_	SpaceAfter=No|Translit=de|LTranslit=de
 8	進行	進行	VERB	_	_	1	xcomp	_	SpaceAfter=No|Translit=jìnxíng|LTranslit=jìnxíng
 9	選舉	選舉	VERB	_	_	12	acl	_	SpaceAfter=No|Translit=xuǎnjǔ|LTranslit=xuǎnjǔ
@@ -7770,8 +7770,8 @@
 # sent_id = 672
 # text = 有議員想提出規程問題。
 # translit = yǒuyìyuánxiǎngtíchūguīchéngwèntí.
-1	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-2	議員	議員	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
+1	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+2	議員	議員	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán|CxnElt=1:Existential-HavePred.Pivot
 3	想	想	AUX	_	_	4	aux	_	SpaceAfter=No|Translit=xiǎng|LTranslit=xiǎng
 4	提出	提出	VERB	_	_	2	acl	_	SpaceAfter=No|Translit=tíchū|LTranslit=tíchū
 5	規程	規程	NOUN	_	_	6	compound	_	SpaceAfter=No|Translit=guīchéng|LTranslit=guīchéng
@@ -7838,13 +7838,13 @@
 # translit = rúguǒdàjiāyǒurènhéguīchéngwèntí,kěyǐtíchū.
 1	如果	如果	SCONJ	_	_	3	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
 2	大家	大家	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=dàjiā|LTranslit=dàjiā
-3	有	有	VERB	_	_	9	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
+3	有	有	VERB	_	_	9	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|CxnElt=9:Conditional-NeutralEpistemic.Protasis
 4	任何	任何	DET	_	_	6	det	_	SpaceAfter=No|Translit=rènhé|LTranslit=rènhé
 5	規程	規程	NOUN	_	_	6	compound	_	SpaceAfter=No|Translit=guīchéng|LTranslit=guīchéng
 6	問題	問題	NOUN	_	_	3	obj	_	SpaceAfter=No|Translit=wèntí|LTranslit=wèntí
 7	，	，	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 8	可以	可以	AUX	_	_	9	aux	_	SpaceAfter=No|Translit=kěyǐ|LTranslit=kěyǐ
-9	提出	提出	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tíchū|LTranslit=tíchū
+9	提出	提出	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tíchū|LTranslit=tíchū|Cxn=Conditional-NeutralEpistemic|CxnElt=9:Conditional-NeutralEpistemic.Apodosis
 10	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 677
@@ -7864,7 +7864,7 @@
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 3	我	我	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 4	想	想	AUX	_	_	5	aux	_	SpaceAfter=No|Translit=xiǎng|LTranslit=xiǎng
-5	問	問	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wèn|LTranslit=wèn
+5	問	問	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wèn|LTranslit=wèn|Cxn=Interrogative-Reduced|CxnElt=5:Interrogative-Reduced.Clause
 6	秘書處	秘書處	NOUN	_	_	9	nsubj	_	SpaceAfter=No|Translit=mìshūchù|LTranslit=mìshūchù
 7	有	有	AUX	_	_	9	aux	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
 8	否	否	ADV	_	_	7	conj	_	SpaceAfter=No|Translit=fǒu|LTranslit=fǒu
@@ -7922,7 +7922,7 @@
 4	我	我	PRON	_	_	3	obj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 5	說	說	VERB	_	_	3	xcomp	_	SpaceAfter=No|Translit=shuō|LTranslit=shuō
 6	，	，	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-7	可以	可以	VERB	_	_	1	conj	_	SpaceAfter=No|Translit=kěyǐ|LTranslit=kěyǐ
+7	可以	可以	VERB	_	_	1	conj	_	SpaceAfter=No|Translit=kěyǐ|LTranslit=kěyǐ|Cxn=Interrogative-Polar-Direct|CxnElt=7:Interrogative-Polar-Direct.Clause
 8	嗎	嗎	PART	_	_	7	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 9	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -7981,11 +7981,11 @@
 2	各位	各位	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=gèwèi|LTranslit=gèwèi
 3	剛才	剛才	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=gāngcái|LTranslit=gāngcái
 4	有	有	AUX	_	_	5	aux	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-5	出席	出席	VERB	_	_	9	advcl	_	SpaceAfter=No|Translit=chūxí|LTranslit=chūxí
+5	出席	出席	VERB	_	_	9	advcl	_	SpaceAfter=No|Translit=chūxí|LTranslit=chūxí|CxnElt=9:Conditional-NeutralEpistemic.Protasis
 6	，	，	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 7	便	便	ADV	_	_	9	advmod	_	SpaceAfter=No|Translit=biàn|LTranslit=biàn
 8	應該	應該	AUX	_	_	9	aux	_	SpaceAfter=No|Translit=yīnggāi|LTranslit=yīnggāi
-9	知道	知道	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhīdào|LTranslit=zhīdào
+9	知道	知道	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhīdào|LTranslit=zhīdào|Cxn=Conditional-NeutralEpistemic|CxnElt=9:Conditional-NeutralEpistemic.Apodosis
 10	情況	情況	NOUN	_	_	11	nsubj	_	SpaceAfter=No|Translit=qíngkuàng|LTranslit=qíngkuàng
 11	如何	如何	ADV	_	_	9	ccomp	_	SpaceAfter=No|Translit=rúhé|LTranslit=rúhé
 12	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
@@ -8039,7 +8039,7 @@
 1	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
 2	議員	議員	NOUN	_	_	4	nsubj	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
 3	想	想	AUX	_	_	4	aux	_	SpaceAfter=No|Translit=xiǎng|LTranslit=xiǎng
-4	確保	確保	VERB	_	_	17	advcl	_	SpaceAfter=No|Translit=quèbǎo|LTranslit=quèbǎo
+4	確保	確保	VERB	_	_	17	advcl	_	SpaceAfter=No|Translit=quèbǎo|LTranslit=quèbǎo|CxnElt=17:Conditional-NeutralEpistemic.Protasis
 5	他	他	PRON	_	_	7	nmod	_	SpaceAfter=No|Translit=tā|LTranslit=tā
 6	的	的	PART	_	_	5	case	_	SpaceAfter=No|Translit=de|LTranslit=de
 7	問題	問題	NOUN	_	_	8	nsubj	_	SpaceAfter=No|Translit=wèntí|LTranslit=wèntí
@@ -8052,7 +8052,7 @@
 14	在	在	ADP	_	_	16	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
 15	其他	其他	DET	_	_	16	det	_	SpaceAfter=No|Translit=qítā|LTranslit=qítā
 16	場合	場合	NOUN	_	_	17	obl	_	SpaceAfter=No|Translit=chǎnghé|LTranslit=chǎnghé
-17	提出	提出	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tíchū|LTranslit=tíchū
+17	提出	提出	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tíchū|LTranslit=tíchū|Cxn=Conditional-NeutralEpistemic|CxnElt=17:Conditional-NeutralEpistemic.Apodosis
 18	。	。	PUNCT	_	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 688
@@ -8076,12 +8076,12 @@
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 2	現在	現在	NOUN	_	_	4	obl:tmod	_	SpaceAfter=No|Translit=xiànzài|LTranslit=xiànzài
 3	想	想	AUX	_	_	4	aux	_	SpaceAfter=No|Translit=xiǎng|LTranslit=xiǎng
-4	問一問	問一問	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wènyīwèn|LTranslit=wènyīwèn
+4	問一問	問一問	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wènyīwèn|LTranslit=wènyīwèn|Cxn=Interrogative-Reduced|CxnElt=4:Interrogative-Reduced.Clause
 5	，	，	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 6	剛才	剛才	ADV	_	_	11	advmod	_	SpaceAfter=No|Translit=gāngcái|LTranslit=gāngcái
-7	有	有	VERB	_	_	4	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
+7	有	有	VERB	_	_	4	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
 8	哪些	哪些	DET	_	_	9	det	_	SpaceAfter=No|Translit=nǎxiē|LTranslit=nǎxiē
-9	議員	議員	NOUN	_	_	7	obj	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
+9	議員	議員	NOUN	_	_	7	obj	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán|CxnElt=7:Existential-HavePred.Pivot
 10	曾	曾	ADV	_	_	11	advmod	_	SpaceAfter=No|Translit=céng|LTranslit=céng
 11	舉手	舉手	VERB	_	_	9	acl	_	SpaceAfter=No|Translit=jǔshǒu|LTranslit=jǔshǒu
 12	想	想	AUX	_	_	13	aux	_	SpaceAfter=No|Translit=xiǎng|LTranslit=xiǎng
@@ -8094,9 +8094,9 @@
 # text = 我看不到。
 # translit = wǒkànbùdào.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
-2	看	看	VERB	_	_	0	root	_	SpaceAfter=No|Translit=kàn|LTranslit=kàn
+2	看	看	VERB	_	_	0	root	_	SpaceAfter=No|Translit=kàn|LTranslit=kàn|Cxn=Resultative|CxnElt=2:Resultative.Event
 3	不	不	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-4	到	到	VERB	_	_	2	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+4	到	到	VERB	_	_	2	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=2:Resultative.ResultState
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 691
@@ -8126,9 +8126,9 @@
 # translit = yīnwèiwǒkànbùdào.
 1	因為	因為	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
 2	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
-3	看	看	VERB	_	_	0	root	_	SpaceAfter=No|Translit=kàn|LTranslit=kàn
+3	看	看	VERB	_	_	0	root	_	SpaceAfter=No|Translit=kàn|LTranslit=kàn|Cxn=Resultative|CxnElt=3:Resultative.Event
 4	不	不	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-5	到	到	VERB	_	_	3	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+5	到	到	VERB	_	_	3	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=3:Resultative.ResultState
 6	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 693
@@ -8241,11 +8241,11 @@
 # translit = rúguǒwǒchùlǐdehuà,biànwéifǎnhuìyìguīzé.
 1	如果	如果	SCONJ	_	_	3	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
 2	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
-3	處理	處理	VERB	_	_	7	advcl	_	SpaceAfter=No|Translit=chùlǐ|LTranslit=chùlǐ
+3	處理	處理	VERB	_	_	7	advcl	_	SpaceAfter=No|Translit=chùlǐ|LTranslit=chùlǐ|CxnElt=7:Conditional-NeutralEpistemic.Protasis
 4	的話	的話	SCONJ	_	_	3	mark	_	SpaceAfter=No|Translit=dehuà|LTranslit=dehuà
 5	，	，	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 6	便	便	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=biàn|LTranslit=biàn
-7	違反	違反	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wéifǎn|LTranslit=wéifǎn
+7	違反	違反	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wéifǎn|LTranslit=wéifǎn|Cxn=Conditional-NeutralEpistemic|CxnElt=7:Conditional-NeutralEpistemic.Apodosis
 8	會議	會議	NOUN	_	_	9	compound	_	SpaceAfter=No|Translit=huìyì|LTranslit=huìyì
 9	規則	規則	NOUN	_	_	7	obj	_	SpaceAfter=No|Translit=guīzé|LTranslit=guīzé
 10	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
@@ -8264,7 +8264,7 @@
 # translit = dàjiārúguǒyàowǒbiǎomíngzhègèhuìyìjiūjìngshìfǒuhéfǎ,wǒ祇nénggòushuō,gēnjùhuìyìguīzé,zhègèhuìyìshìhéfǎde.
 1	大家	大家	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=dàjiā|LTranslit=dàjiā
 2	如果	如果	SCONJ	_	_	3	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
-3	要	要	VERB	_	_	17	advcl	_	SpaceAfter=No|Translit=yào|LTranslit=yào
+3	要	要	VERB	_	_	17	advcl	_	SpaceAfter=No|Translit=yào|LTranslit=yào|CxnElt=17:Conditional-NeutralEpistemic.Protasis
 4	我	我	PRON	_	_	3	obj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 5	表明	表明	VERB	_	_	3	xcomp	_	SpaceAfter=No|Translit=biǎomíng|LTranslit=biǎomíng
 6	這	這	DET	_	_	8	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -8278,7 +8278,7 @@
 14	我	我	PRON	_	_	17	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 15	祇	祇	ADV	_	_	17	advmod	_	SpaceAfter=No|Translit=祇|LTranslit=祇
 16	能夠	能夠	AUX	_	_	17	aux	_	SpaceAfter=No|Translit=nénggòu|LTranslit=nénggòu
-17	說	說	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shuō|LTranslit=shuō
+17	說	說	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shuō|LTranslit=shuō|Cxn=Conditional-NeutralEpistemic|CxnElt=17:Conditional-NeutralEpistemic.Apodosis
 18	，	，	PUNCT	_	_	21	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 19	根據	根據	ADP	_	_	21	case	_	SpaceAfter=No|Translit=gēnjù|LTranslit=gēnjù
 20	會議	會議	NOUN	_	_	21	compound	_	SpaceAfter=No|Translit=huìyì|LTranslit=huìyì
@@ -8298,13 +8298,13 @@
 1	議員	議員	NOUN	_	_	4	nsubj	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
 2	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
 3	想	想	AUX	_	_	4	aux	_	SpaceAfter=No|Translit=xiǎng|LTranslit=xiǎng
-4	提出	提出	VERB	_	_	10	advcl	_	SpaceAfter=No|Translit=tíchū|LTranslit=tíchū
+4	提出	提出	VERB	_	_	10	advcl	_	SpaceAfter=No|Translit=tíchū|LTranslit=tíchū|CxnElt=10:Conditional-NeutralEpistemic.Protasis
 5	規程	規程	NOUN	_	_	6	compound	_	SpaceAfter=No|Translit=guīchéng|LTranslit=guīchéng
 6	問題	問題	NOUN	_	_	4	obj	_	SpaceAfter=No|Translit=wèntí|LTranslit=wèntí
 7	，	，	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 8	我	我	PRON	_	_	10	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 9	再	再	ADV	_	_	10	advmod	_	SpaceAfter=No|Translit=zài|LTranslit=zài
-10	請	請	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǐng|LTranslit=qǐng
+10	請	請	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǐng|LTranslit=qǐng|Cxn=Conditional-NeutralEpistemic|CxnElt=10:Conditional-NeutralEpistemic.Apodosis
 11	大家	大家	PRON	_	_	10	obj	_	SpaceAfter=No|Translit=dàjiā|LTranslit=dàjiā
 12	先	先	ADV	_	_	13	advmod	_	SpaceAfter=No|Translit=xiān|LTranslit=xiān
 13	返回	返回	VERB	_	_	10	xcomp	_	SpaceAfter=No|Translit=fǎnhuí|LTranslit=fǎnhuí
@@ -8330,7 +8330,7 @@
 2	不	不	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
 3	離開	離開	VERB	_	_	5	advcl	_	SpaceAfter=No|Translit=líkāi|LTranslit=líkāi
 4	又	又	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=yòu|LTranslit=yòu
-5	怎樣	怎樣	ADV	_	_	0	root	_	SpaceAfter=No|Translit=zěnyàng|LTranslit=zěnyàng
+5	怎樣	怎樣	ADV	_	_	0	root	_	SpaceAfter=No|Translit=zěnyàng|LTranslit=zěnyàng|Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause,5:Interrogative-WHInfo-Direct.WHWord
 6	呢	呢	PART	_	_	5	discourse:sp	_	SpaceAfter=No|Translit=ne|LTranslit=ne
 7	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -8341,12 +8341,12 @@
 2	議員	議員	NOUN	_	_	5	nsubj	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
 3	真的	真的	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=zhēnde|LTranslit=zhēnde
 4	不	不	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-5	返回	返回	VERB	_	_	10	advcl	_	SpaceAfter=No|Translit=fǎnhuí|LTranslit=fǎnhuí
+5	返回	返回	VERB	_	_	10	advcl	_	SpaceAfter=No|Translit=fǎnhuí|LTranslit=fǎnhuí|CxnElt=10:Conditional-NeutralEpistemic.Protasis
 6	座位	座位	NOUN	_	_	5	obj	_	SpaceAfter=No|Translit=zuòwèi|LTranslit=zuòwèi
 7	，	，	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 8	也	也	ADV	_	_	10	advmod	_	SpaceAfter=No|Translit=yě|LTranslit=yě
 9	不	不	ADV	_	_	10	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-10	要緊	要緊	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=yàojǐn|LTranslit=yàojǐn
+10	要緊	要緊	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=yàojǐn|LTranslit=yàojǐn|Cxn=Conditional-NeutralEpistemic|CxnElt=10:Conditional-NeutralEpistemic.Apodosis
 11	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 706
@@ -8410,11 +8410,11 @@
 # text = 如果有其他問題，請議員在其他場合提出。
 # translit = rúguǒyǒuqítāwèntí,qǐngyìyuánzàiqítāchǎnghétíchū.
 1	如果	如果	SCONJ	_	_	2	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
-2	有	有	VERB	_	_	6	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
+2	有	有	VERB	_	_	6	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred|CxnElt=6:Conditional-NeutralEpistemic.Protasis
 3	其他	其他	DET	_	_	4	det	_	SpaceAfter=No|Translit=qítā|LTranslit=qítā
-4	問題	問題	NOUN	_	_	2	obj	_	SpaceAfter=No|Translit=wèntí|LTranslit=wèntí
+4	問題	問題	NOUN	_	_	2	obj	_	SpaceAfter=No|Translit=wèntí|LTranslit=wèntí|CxnElt=2:Existential-HavePred.Pivot
 5	，	，	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-6	請	請	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǐng|LTranslit=qǐng
+6	請	請	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǐng|LTranslit=qǐng|Cxn=Conditional-NeutralEpistemic|CxnElt=6:Conditional-NeutralEpistemic.Apodosis
 7	議員	議員	NOUN	_	_	6	obj	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
 8	在	在	ADP	_	_	10	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
 9	其他	其他	DET	_	_	10	det	_	SpaceAfter=No|Translit=qítā|LTranslit=qítā
@@ -8478,8 +8478,8 @@
 # translit = wǒmenyǐtīngbatādejiěshì.
 1	我們	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
 2	已	已	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=yǐ|LTranslit=yǐ
-3	聽	聽	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tīng|LTranslit=tīng
-4	罷	罷	VERB	_	_	3	compound:vv	_	SpaceAfter=No|Translit=ba|LTranslit=ba
+3	聽	聽	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tīng|LTranslit=tīng|Cxn=Resultative|CxnElt=3:Resultative.Event
+4	罷	罷	VERB	_	_	3	compound:vv	_	SpaceAfter=No|Translit=ba|LTranslit=ba|CxnElt=3:Resultative.ResultState
 5	他	他	PRON	_	_	7	nmod	_	SpaceAfter=No|Translit=tā|LTranslit=tā
 6	的	的	PART	_	_	5	case	_	SpaceAfter=No|Translit=de|LTranslit=de
 7	解釋	解釋	NOUN	_	_	4	obj	_	SpaceAfter=No|Translit=jiěshì|LTranslit=jiěshì
@@ -8565,8 +8565,8 @@
 3	暫時	暫時	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=zànshí|LTranslit=zànshí
 4	仍	仍	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=réng|LTranslit=réng
 5	未	未	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
-6	收	收	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shōu|LTranslit=shōu
-7	到	到	VERB	_	_	6	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+6	收	收	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shōu|LTranslit=shōu|Cxn=Resultative|CxnElt=6:Resultative.Event
+7	到	到	VERB	_	_	6	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=6:Resultative.ResultState
 8	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 721
@@ -8666,8 +8666,8 @@
 4	應	應	AUX	_	_	5	aux	_	SpaceAfter=No|Translit=yīng|LTranslit=yīng
 5	待	待	VERB	_	_	2	ccomp	_	SpaceAfter=No|Translit=dài|LTranslit=dài
 6	他	他	PRON	_	_	7	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
-7	收	收	VERB	_	_	5	ccomp	_	SpaceAfter=No|Translit=shōu|LTranslit=shōu
-8	到	到	VERB	_	_	7	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+7	收	收	VERB	_	_	5	ccomp	_	SpaceAfter=No|Translit=shōu|LTranslit=shōu|Cxn=Resultative|CxnElt=7:Resultative.Event
+8	到	到	VERB	_	_	7	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=7:Resultative.ResultState
 9	有關	有關	ADJ	_	_	10	amod	_	SpaceAfter=No|Translit=yǒuguān|LTranslit=yǒuguān
 10	文件	文件	NOUN	_	_	7	obj	_	SpaceAfter=No|Translit=wénjiàn|LTranslit=wénjiàn
 11	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
@@ -8684,7 +8684,7 @@
 7	後	後	ADP	_	_	6	case:loc	_	SpaceAfter=No|Translit=hòu|LTranslit=hòu
 8	，	，	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 9	才	才	ADV	_	_	10	advmod	_	SpaceAfter=No|Translit=cái|LTranslit=cái
-10	展開	展開	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhǎnkāi|LTranslit=zhǎnkāi
+10	展開	展開	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhǎnkāi|LTranslit=zhǎnkāi|Cxn=Interrogative-Reduced|CxnElt=10:Interrogative-Reduced.Clause
 11	選舉	選舉	VERB	_	_	12	acl	_	SpaceAfter=No|Translit=xuǎnjǔ|LTranslit=xuǎnjǔ
 12	程序	程序	NOUN	_	_	10	obj	_	SpaceAfter=No|Translit=chéngxù|LTranslit=chéngxù
 13	呢	呢	PART	_	_	10	discourse:sp	_	SpaceAfter=No|Translit=ne|LTranslit=ne
@@ -8834,7 +8834,7 @@
 # translit = rúguǒdàjiārènwèiliángjūn彥yìyuándedáfùwèinénghuíyīngdàjiādetíwèn,dàjiākěyǐjuédìngxúnqiú……
 1	如果	如果	SCONJ	_	_	3	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
 2	大家	大家	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=dàjiā|LTranslit=dàjiā
-3	認為	為	VERB	_	_	17	advcl	_	SpaceAfter=No|Translit=rènwèi|LTranslit=wèi
+3	認為	為	VERB	_	_	17	advcl	_	SpaceAfter=No|Translit=rènwèi|LTranslit=wèi|CxnElt=17:Conditional-NeutralEpistemic.Protasis
 4	梁君彥	梁君彥	PROPN	_	_	7	nmod	_	SpaceAfter=No|Translit=liángjūn彥|LTranslit=liángjūn彥
 5	議員	議員	NOUN	_	_	4	flat	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
 6	的	的	PART	_	_	5	case	_	SpaceAfter=No|Translit=de|LTranslit=de
@@ -8848,7 +8848,7 @@
 14	，	，	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 15	大家	大家	PRON	_	_	17	nsubj	_	SpaceAfter=No|Translit=dàjiā|LTranslit=dàjiā
 16	可以	可以	AUX	_	_	17	aux	_	SpaceAfter=No|Translit=kěyǐ|LTranslit=kěyǐ
-17	決定	決定	VERB	_	_	0	root	_	SpaceAfter=No|Translit=juédìng|LTranslit=juédìng
+17	決定	決定	VERB	_	_	0	root	_	SpaceAfter=No|Translit=juédìng|LTranslit=juédìng|Cxn=Conditional-NeutralEpistemic|CxnElt=17:Conditional-NeutralEpistemic.Apodosis
 18	尋求	尋求	VERB	_	_	17	xcomp	_	SpaceAfter=No|Translit=xúnqiú|LTranslit=xúnqiú
 19	……	……	PUNCT	_	_	17	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
@@ -8863,7 +8863,7 @@
 6	被	被	AUX	_	_	7	aux:pass	_	SpaceAfter=No|Translit=bèi|LTranslit=bèi
 7	disqualified	disqualified	VERB	_	_	0	root	_	SpaceAfter=No|Translit=disqualified|LTranslit=disqualified
 8	，	，	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-9	對	對	VERB	_	_	7	parataxis	_	SpaceAfter=No|Translit=duì|LTranslit=duì
+9	對	對	VERB	_	_	7	parataxis	_	SpaceAfter=No|Translit=duì|LTranslit=duì|Cxn=Interrogative-Polar-Direct|CxnElt=9:Interrogative-Polar-Direct.Clause
 10	嗎	嗎	PART	_	_	9	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 11	？	？	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -8880,16 +8880,16 @@
 8	是	是	VERB	_	_	4	ccomp	_	SpaceAfter=No|Translit=shì|LTranslit=shì
 9	否	否	ADV	_	_	8	conj	_	SpaceAfter=No|Translit=fǒu|LTranslit=fǒu
 10	真的	真的	ADV	_	_	11	advmod	_	SpaceAfter=No|Translit=zhēnde|LTranslit=zhēnde
-11	有	有	VERB	_	_	8	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
+11	有	有	VERB	_	_	8	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
 12	合法	合法	ADJ	_	_	13	amod	_	SpaceAfter=No|Translit=héfǎ|LTranslit=héfǎ
-13	權利	權利	NOUN	_	_	11	obj	_	SpaceAfter=No|Translit=quánlì|LTranslit=quánlì
+13	權利	權利	NOUN	_	_	11	obj	_	SpaceAfter=No|Translit=quánlì|LTranslit=quánlì|CxnElt=11:Existential-HavePred.Pivot
 14	參選	參選	VERB	_	_	13	acl	_	SpaceAfter=No|Translit=cānxuǎn|LTranslit=cānxuǎn
 15	，	，	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 16	但	但	ADV	_	_	20	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
 17	梁耀忠	梁耀忠	PRON	_	_	20	nsubj	_	SpaceAfter=No|Translit=liángyàozhōng|LTranslit=liángyàozhōng
 18	議員	議員	NOUN	_	_	17	flat	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
 19	卻	卻	ADV	_	_	20	advmod	_	SpaceAfter=No|Translit=què|LTranslit=què
-20	要求	要求	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yàoqiú|LTranslit=yàoqiú
+20	要求	要求	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yàoqiú|LTranslit=yàoqiú|Cxn=Interrogative-Polar-Direct|CxnElt=20:Interrogative-Polar-Direct.Clause
 21	我們	我	PRON	_	_	20	obj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
 22	自行	自行	ADV	_	_	23	advmod	_	SpaceAfter=No|Translit=zìxíng|LTranslit=zìxíng
 23	考慮	考慮	VERB	_	_	20	xcomp	_	SpaceAfter=No|Translit=kǎolǜ|LTranslit=kǎolǜ
@@ -8905,7 +8905,7 @@
 # text = 你是否也可要求選民自行決定是否投票給梁天琦？
 # translit = nǐshìfǒuyěkěyàoqiúxuǎnmínzìxíngjuédìngshìfǒutóupiàogěiliángtiān琦?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-2	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+2	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Interrogative-Reduced|CxnElt=2:Interrogative-Reduced.Clause
 3	否	否	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=fǒu|LTranslit=fǒu
 4	也	也	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=yě|LTranslit=yě
 5	可	可	AUX	_	_	6	aux	_	SpaceAfter=No|Translit=kě|LTranslit=kě
@@ -9048,7 +9048,7 @@
 1	但	但	CCONJ	_	_	9	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
 2	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
 3	暫時	暫時	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=zànshí|LTranslit=zànshí
-4	沒有	有	VERB	_	Polarity=Neg	14	advcl	_	SpaceAfter=No|Translit=méiyǒu|LTranslit=yǒu
+4	沒有	有	VERB	_	Polarity=Neg	14	advcl	_	SpaceAfter=No|Translit=méiyǒu|LTranslit=yǒu|CxnElt=14:Conditional-NeutralEpistemic.Protasis
 5	正本	正本	NOUN	_	_	4	obj	_	SpaceAfter=No|Translit=zhèngběn|LTranslit=zhèngběn
 6	，	，	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 7	向	向	ADP	_	_	8	case	_	SpaceAfter=No|Translit=xiàng|LTranslit=xiàng
@@ -9058,7 +9058,7 @@
 11	份	份	NOUN	_	NounType=Clf	10	clf	_	SpaceAfter=No|Translit=fèn|LTranslit=fèn
 12	copy	copy	NOUN	_	_	9	obj	_	SpaceAfter=No|Translit=copy|LTranslit=copy
 13	也	也	ADV	_	_	14	advmod	_	SpaceAfter=No|Translit=yě|LTranslit=yě
-14	可以	可以	VERB	_	_	0	root	_	SpaceAfter=No|Translit=kěyǐ|LTranslit=kěyǐ
+14	可以	可以	VERB	_	_	0	root	_	SpaceAfter=No|Translit=kěyǐ|LTranslit=kěyǐ|Cxn=Conditional-NeutralEpistemic|CxnElt=14:Conditional-NeutralEpistemic.Apodosis
 15	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 746
@@ -9096,11 +9096,11 @@
 # translit = shìwènwǒmenzěnkěyǐzàizhèlijìnxíngxuǎnjǔdechéngxùne?
 1	試問	試問	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shìwèn|LTranslit=shìwèn
 2	我們	我	PRON	_	_	7	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
-3	怎	怎	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=zěn|LTranslit=zěn
+3	怎	怎	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=zěn|LTranslit=zěn|CxnElt=7:Interrogative-WHInfo-Direct.WHWord
 4	可以	可以	AUX	_	_	7	aux	_	SpaceAfter=No|Translit=kěyǐ|LTranslit=kěyǐ
 5	在	在	ADP	_	_	6	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
 6	這裡	這裡	PRON	_	_	7	obl	_	SpaceAfter=No|Translit=zhèli|LTranslit=zhèli
-7	進行	進行	VERB	_	_	1	ccomp	_	SpaceAfter=No|Translit=jìnxíng|LTranslit=jìnxíng
+7	進行	進行	VERB	_	_	1	ccomp	_	SpaceAfter=No|Translit=jìnxíng|LTranslit=jìnxíng|Cxn=Interrogative-WHInfo-Direct|CxnElt=7:Interrogative-WHInfo-Direct.Clause
 8	選舉	選舉	VERB	_	_	10	acl	_	SpaceAfter=No|Translit=xuǎnjǔ|LTranslit=xuǎnjǔ
 9	的	的	PART	_	_	8	case	_	SpaceAfter=No|Translit=de|LTranslit=de
 10	程序	程序	NOUN	_	_	7	obj	_	SpaceAfter=No|Translit=chéngxù|LTranslit=chéngxù
@@ -9164,12 +9164,12 @@
 13	如果	如果	SCONJ	_	_	16	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
 14	大家	大家	PRON	_	_	16	nsubj	_	SpaceAfter=No|Translit=dàjiā|LTranslit=dàjiā
 15	想	想	AUX	_	_	16	aux	_	SpaceAfter=No|Translit=xiǎng|LTranslit=xiǎng
-16	澄清	澄清	VERB	_	_	21	advcl	_	SpaceAfter=No|Translit=澄qīng|LTranslit=澄qīng
+16	澄清	澄清	VERB	_	_	21	advcl	_	SpaceAfter=No|Translit=澄qīng|LTranslit=澄qīng|CxnElt=21:Conditional-NeutralEpistemic.Protasis
 17	的話	的話	PART	_	_	16	mark	_	SpaceAfter=No|Translit=dehuà|LTranslit=dehuà
 18	，	，	PUNCT	_	_	16	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 19	便	便	ADV	_	_	21	advmod	_	SpaceAfter=No|Translit=biàn|LTranslit=biàn
 20	應該	應該	AUX	_	_	21	aux	_	SpaceAfter=No|Translit=yīnggāi|LTranslit=yīnggāi
-21	透過	透過	ADP	_	_	4	advcl	_	SpaceAfter=No|Translit=tòuguò|LTranslit=tòuguò
+21	透過	透過	ADP	_	_	4	advcl	_	SpaceAfter=No|Translit=tòuguò|LTranslit=tòuguò|Cxn=Conditional-NeutralEpistemic|CxnElt=21:Conditional-NeutralEpistemic.Apodosis
 22	其他	其他	DET	_	_	23	det	_	SpaceAfter=No|Translit=qítā|LTranslit=qítā
 23	途徑	途徑	NOUN	_	_	21	obj	_	SpaceAfter=No|Translit=tújìng|LTranslit=tújìng
 24	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
@@ -9272,12 +9272,12 @@
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 3	如果	如果	SCONJ	_	_	5	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
 4	要	要	AUX	_	_	5	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
-5	進行	進行	VERB	_	_	9	advcl	_	SpaceAfter=No|Translit=jìnxíng|LTranslit=jìnxíng
+5	進行	進行	VERB	_	_	9	advcl	_	SpaceAfter=No|Translit=jìnxíng|LTranslit=jìnxíng|CxnElt=9:Conditional-NeutralEpistemic.Protasis
 6	選舉	選舉	NOUN	_	_	5	obj	_	SpaceAfter=No|Translit=xuǎnjǔ|LTranslit=xuǎnjǔ
 7	的話	的話	SCONJ	_	_	5	discourse	_	SpaceAfter=No|Translit=dehuà|LTranslit=dehuà
 8	，	，	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-9	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-10	人	人	NOUN	_	_	9	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén
+9	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Conditional-NeutralEpistemic,Existential-HavePred|CxnElt=9:Conditional-NeutralEpistemic.Apodosis
+10	人	人	NOUN	_	_	9	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén|CxnElt=9:Existential-HavePred.Pivot
 11	將	將	ADV	_	_	22	advmod	_	SpaceAfter=No|Translit=jiāng|LTranslit=jiāng
 12	於	於	ADP	_	_	15	case	_	SpaceAfter=No|Translit=yú|LTranslit=yú
 13	稍後	稍後	NOUN	_	_	15	compound	_	SpaceAfter=No|Translit=shāohòu|LTranslit=shāohòu
@@ -9411,8 +9411,8 @@
 5	坐	坐	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò
 6	在	在	ADP	_	_	7	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
 7	這裡	這裡	PRON	_	_	5	obl	_	SpaceAfter=No|Translit=zhèli|LTranslit=zhèli
-8	做	做	VERB	_	_	6	conj	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò
-9	甚麼	甚麼	PRON	_	_	8	obj	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
+8	做	做	VERB	_	_	6	conj	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò|Cxn=Interrogative-WHInfo-Direct|CxnElt=8:Interrogative-WHInfo-Direct.Clause
+9	甚麼	甚麼	PRON	_	_	8	obj	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=8:Interrogative-WHInfo-Direct.WHWord
 10	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 767
@@ -9565,7 +9565,7 @@
 # text = 大家是否要一直這樣繼續下去呢？
 # translit = dàjiāshìfǒuyàoyīzhízhèyàngjìxùxiàqùne?
 1	大家	大家	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=dàjiā|LTranslit=dàjiā
-2	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+2	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Interrogative-Reduced|CxnElt=2:Interrogative-Reduced.Clause
 3	否	否	ADV	_	_	2	conj	_	SpaceAfter=No|Translit=fǒu|LTranslit=fǒu
 4	要	要	AUX	_	_	7	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
 5	一直	一直	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=yīzhí|LTranslit=yīzhí
@@ -9581,14 +9581,14 @@
 1	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
 2	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 3	不	不	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-4	影響	影響	VERB	_	_	11	advcl	_	SpaceAfter=No|Translit=yǐngxiǎng|LTranslit=yǐngxiǎng
+4	影響	影響	VERB	_	_	11	advcl	_	SpaceAfter=No|Translit=yǐngxiǎng|LTranslit=yǐngxiǎng|CxnElt=11:Conditional-NeutralEpistemic.Protasis
 5	大家	大家	PRON	_	_	8	nmod	_	SpaceAfter=No|Translit=dàjiā|LTranslit=dàjiā
 6	的	的	PART	_	_	5	case	_	SpaceAfter=No|Translit=de|LTranslit=de
 7	投票	投票	NOUN	_	_	8	compound	_	SpaceAfter=No|Translit=tóupiào|LTranslit=tóupiào
 8	程序	程序	NOUN	_	_	4	obj	_	SpaceAfter=No|Translit=chéngxù|LTranslit=chéngxù
 9	，	，	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 10	我	我	PRON	_	_	11	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
-11	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+11	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Conditional-NeutralEpistemic|CxnElt=11:Conditional-NeutralEpistemic.Apodosis
 12	不	不	ADV	_	_	14	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
 13	會	會	AUX	_	_	14	aux	_	SpaceAfter=No|Translit=huì|LTranslit=huì
 14	阻止	阻止	VERB	_	_	11	ccomp	_	SpaceAfter=No|Translit=zǔzhǐ|LTranslit=zǔzhǐ
@@ -9634,8 +9634,8 @@
 8	你們	你們	PRON	_	_	9	nsubj	_	SpaceAfter=No|Translit=nǐmen|LTranslit=nǐmen
 9	是	是	VERB	_	_	7	ccomp	_	SpaceAfter=No|Translit=shì|LTranslit=shì
 10	否	否	ADV	_	_	9	conj	_	SpaceAfter=No|Translit=fǒu|LTranslit=fǒu
-11	有	有	VERB	_	_	13	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-12	權	權	NOUN	_	_	11	obj	_	SpaceAfter=No|Translit=quán|LTranslit=quán
+11	有	有	VERB	_	_	13	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+12	權	權	NOUN	_	_	11	obj	_	SpaceAfter=No|Translit=quán|LTranslit=quán|CxnElt=11:Existential-HavePred.Pivot
 13	投票	投票	VERB	_	_	9	conj	_	SpaceAfter=No|Translit=tóupiào|LTranslit=tóupiào
 14	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
@@ -9655,8 +9655,8 @@
 11	包括	包括	VERB	_	_	9	acl	_	SpaceAfter=No|Translit=bāokuò|LTranslit=bāokuò
 12	候選人	候選人	NOUN	_	_	11	obj	_	SpaceAfter=No|Translit=houxuǎnrén|LTranslit=houxuǎnrén
 13	和	和	CCONJ	_	_	18	cc	_	SpaceAfter=No|Translit=hé|LTranslit=hé
-14	有	有	ADJ	_	_	16	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-15	資格	資格	NOUN	_	_	14	obj	_	SpaceAfter=No|Translit=zīgé|LTranslit=zīgé
+14	有	有	ADJ	_	_	16	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+15	資格	資格	NOUN	_	_	14	obj	_	SpaceAfter=No|Translit=zīgé|LTranslit=zīgé|CxnElt=14:Existential-HavePred.Pivot
 16	投票	投票	VERB	_	_	18	acl	_	SpaceAfter=No|Translit=tóupiào|LTranslit=tóupiào
 17	的	的	PART	_	_	16	mark:rel	_	SpaceAfter=No|Translit=de|LTranslit=de
 18	議員	議員	NOUN	_	_	12	conj	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
@@ -9695,12 +9695,12 @@
 1	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
 2	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 3	要	要	AUX	_	_	4	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
-4	提出	提出	VERB	_	_	9	advcl	_	SpaceAfter=No|Translit=tíchū|LTranslit=tíchū
+4	提出	提出	VERB	_	_	9	advcl	_	SpaceAfter=No|Translit=tíchū|LTranslit=tíchū|CxnElt=9:Conditional-NeutralEpistemic.Protasis
 5	，	，	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 6	可以	可以	AUX	_	_	9	aux	_	SpaceAfter=No|Translit=kěyǐ|LTranslit=kěyǐ
 7	向	向	ADP	_	_	8	case	_	SpaceAfter=No|Translit=xiàng|LTranslit=xiàng
 8	秘書處	秘書處	NOUN	_	_	9	obl	_	SpaceAfter=No|Translit=mìshūchù|LTranslit=mìshūchù
-9	提出	提出	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tíchū|LTranslit=tíchū
+9	提出	提出	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tíchū|LTranslit=tíchū|Cxn=Conditional-NeutralEpistemic|CxnElt=9:Conditional-NeutralEpistemic.Apodosis
 10	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 784
@@ -9959,7 +9959,7 @@
 # translit = wǒxiǎngqǐngnǐjuédìng,miànduìnàmeduōchéngxùgōngyìwèntí,yīngfǒujìxùjìnxínghuìyì,xuǎnchūyīwèiméiyǒurènhédàibiǎoxìngdelìfǎhuìzhǔxí?
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 2	想	想	AUX	_	_	3	aux	_	SpaceAfter=No|Translit=xiǎng|LTranslit=xiǎng
-3	請	請	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǐng|LTranslit=qǐng
+3	請	請	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǐng|LTranslit=qǐng|Cxn=Interrogative-Reduced|CxnElt=3:Interrogative-Reduced.Clause
 4	你	你	PRON	_	_	3	obj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 5	決定	決定	VERB	_	_	3	xcomp	_	SpaceAfter=No|Translit=juédìng|LTranslit=juédìng
 6	，	，	PUNCT	_	_	16	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
@@ -10079,8 +10079,8 @@
 # sent_id = 802
 # text = 有議員沒有合理理由而在你身後及旁邊站着。
 # translit = yǒuyìyuánméiyǒuhélǐlǐyóu'érzàinǐshēnhòujípángbiānzhànzhe.
-1	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-2	議員	議員	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
+1	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+2	議員	議員	NOUN	_	_	1	obj	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán|CxnElt=1:Existential-HavePred.Pivot
 3	沒有	有	VERB	_	Polarity=Neg	12	advcl	_	SpaceAfter=No|Translit=méiyǒu|LTranslit=yǒu
 4	合理	合理	ADJ	_	_	5	compound	_	SpaceAfter=No|Translit=hélǐ|LTranslit=hélǐ
 5	理由	理由	NOUN	_	_	3	obj	_	SpaceAfter=No|Translit=lǐyóu|LTranslit=lǐyóu
@@ -10133,11 +10133,11 @@
 5	勸諭	勸諭	NOUN	_	_	3	obj	_	SpaceAfter=No|Translit=quàn諭|LTranslit=quàn諭
 6	仍	仍	ADV	_	_	8	advmod	_	SpaceAfter=No|Translit=réng|LTranslit=réng
 7	不	不	ADV	_	_	8	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-8	返回	返回	VERB	_	_	12	advcl	_	SpaceAfter=No|Translit=fǎnhuí|LTranslit=fǎnhuí
+8	返回	返回	VERB	_	_	12	advcl	_	SpaceAfter=No|Translit=fǎnhuí|LTranslit=fǎnhuí|CxnElt=12:Conditional-NeutralEpistemic.Protasis
 9	座位	座位	NOUN	_	_	8	obj	_	SpaceAfter=No|Translit=zuòwèi|LTranslit=zuòwèi
 10	，	，	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 11	我	我	PRON	_	_	12	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
-12	認為	為	VERB	_	_	0	root	_	SpaceAfter=No|Translit=rènwèi|LTranslit=wèi
+12	認為	為	VERB	_	_	0	root	_	SpaceAfter=No|Translit=rènwèi|LTranslit=wèi|Cxn=Conditional-NeutralEpistemic|CxnElt=12:Conditional-NeutralEpistemic.Apodosis
 13	你	你	PRON	_	_	15	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 14	應	應	AUX	_	_	15	aux	_	SpaceAfter=No|Translit=yīng|LTranslit=yīng
 15	執行	執行	VERB	_	_	12	ccomp	_	SpaceAfter=No|Translit=zhíxíng|LTranslit=zhíxíng
@@ -10201,10 +10201,10 @@
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 2	亦	亦	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=yì|LTranslit=yì
 3	認為	為	VERB	_	_	0	root	_	SpaceAfter=No|Translit=rènwèi|LTranslit=wèi
-4	有	有	VERB	_	_	3	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
+4	有	有	VERB	_	_	3	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
 5	數	數	DET	_	_	7	det	_	SpaceAfter=No|Translit=shù|LTranslit=shù
 6	位	位	NOUN	_	NounType=Clf	5	clf	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
-7	議員	議員	NOUN	_	_	4	obj	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
+7	議員	議員	NOUN	_	_	4	obj	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán|CxnElt=4:Existential-HavePred.Pivot
 8	沒有	有	VERB	_	Polarity=Neg	13	advcl	_	SpaceAfter=No|Translit=méiyǒu|LTranslit=yǒu
 9	依照	依照	ADP	_	_	12	case	_	SpaceAfter=No|Translit=yīzhào|LTranslit=yīzhào
 10	誓詞	誓詞	NOUN	_	_	12	nmod	_	SpaceAfter=No|Translit=shìcí|LTranslit=shìcí
@@ -10292,8 +10292,8 @@
 3	這	這	DET	_	_	4	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
 4	做法	做法	NOUN	_	_	6	nsubj	_	SpaceAfter=No|Translit=zuòfǎ|LTranslit=zuòfǎ
 5	已經	已經	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=yǐjīng|LTranslit=yǐjīng
-6	兼顧	兼顧	VERB	_	_	2	ccomp	_	SpaceAfter=No|Translit=jiāngù|LTranslit=jiāngù
-7	到	到	VERB	_	_	6	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+6	兼顧	兼顧	VERB	_	_	2	ccomp	_	SpaceAfter=No|Translit=jiāngù|LTranslit=jiāngù|Cxn=Resultative|CxnElt=6:Resultative.Event
+7	到	到	VERB	_	_	6	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=6:Resultative.ResultState
 8	人情	人情	NOUN	_	_	11	nmod	_	SpaceAfter=No|Translit=rénqíng|LTranslit=rénqíng
 9	上	上	ADP	_	_	8	case:loc	_	SpaceAfter=No|Translit=shàng|LTranslit=shàng
 10	的	的	PART	_	_	8	case	_	SpaceAfter=No|Translit=de|LTranslit=de
@@ -10348,8 +10348,8 @@
 7	表示	表示	VERB	_	_	0	root	_	SpaceAfter=No|Translit=biǎoshì|LTranslit=biǎoshì
 8	事情	事情	NOUN	_	_	10	nsubj	_	SpaceAfter=No|Translit=shìqíng|LTranslit=shìqíng
 9	已經	已經	ADV	_	_	10	advmod	_	SpaceAfter=No|Translit=yǐjīng|LTranslit=yǐjīng
-10	處理	處理	VERB	_	_	7	ccomp	_	SpaceAfter=No|Translit=chùlǐ|LTranslit=chùlǐ
-11	好	好	ADJ	_	_	10	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
+10	處理	處理	VERB	_	_	7	ccomp	_	SpaceAfter=No|Translit=chùlǐ|LTranslit=chùlǐ|Cxn=Resultative|CxnElt=10:Resultative.Event
+11	好	好	ADJ	_	_	10	compound:vv	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo|CxnElt=10:Resultative.ResultState
 12	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 817
@@ -10469,8 +10469,8 @@
 3	選舉	選舉	NOUN	_	_	4	obl	_	SpaceAfter=No|Translit=xuǎnjǔ|LTranslit=xuǎnjǔ
 4	一樣	一樣	ADJ	_	_	6	advcl	_	SpaceAfter=No|Translit=yīyàng|LTranslit=yīyàng
 5	，	，	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-6	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-7	人	人	NOUN	_	_	6	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén
+6	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+7	人	人	NOUN	_	_	6	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén|CxnElt=6:Existential-HavePred.Pivot
 8	可能	可能	AUX	_	_	10	aux	_	SpaceAfter=No|Translit=kěnéng|LTranslit=kěnéng
 9	會	會	AUX	_	_	10	aux	_	SpaceAfter=No|Translit=huì|LTranslit=huì
 10	質疑	質疑	VERB	_	_	7	acl	_	SpaceAfter=No|Translit=zhìyí|LTranslit=zhìyí
@@ -10543,8 +10543,8 @@
 1	主席	主席	NOUN	_	_	4	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 3	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
-4	留意	留意	VERB	_	_	0	root	_	SpaceAfter=No|Translit=liúyì|LTranslit=liúyì
-5	到	到	VERB	_	_	4	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+4	留意	留意	VERB	_	_	0	root	_	SpaceAfter=No|Translit=liúyì|LTranslit=liúyì|Cxn=Resultative|CxnElt=4:Resultative.Event
+5	到	到	VERB	_	_	4	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=4:Resultative.ResultState
 6	有些	有些	DET	_	_	7	det	_	SpaceAfter=No|Translit=yǒuxiē|LTranslit=yǒuxiē
 7	同事	同事	NOUN	_	_	18	nsubj	_	SpaceAfter=No|Translit=tóngshì|LTranslit=tóngshì
 8	就	就	PART	_	_	17	case	_	SpaceAfter=No|Translit=jiù|LTranslit=jiù
@@ -10697,8 +10697,8 @@
 # translit = zàiwǒmenkàndàozhèngshìwénjiànqián,shínányǐdānpíngyīfēngdiànyóuhuòxiāngguānwénjiàndefùběnyǔyǐquèrèn,jíshǐwǒmenxiāngxìntā.
 1	在	在	ADP	_	_	3	mark	_	SpaceAfter=No|Translit=zài|LTranslit=zài
 2	我們	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
-3	看	看	VERB	_	_	20	advcl	_	SpaceAfter=No|Translit=kàn|LTranslit=kàn
-4	到	到	VERB	_	_	3	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+3	看	看	VERB	_	_	20	advcl	_	SpaceAfter=No|Translit=kàn|LTranslit=kàn|Cxn=Resultative|CxnElt=3:Resultative.Event
+4	到	到	VERB	_	_	3	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=3:Resultative.ResultState
 5	正式	正式	ADJ	_	_	6	amod	_	SpaceAfter=No|Translit=zhèngshì|LTranslit=zhèngshì
 6	文件	文件	NOUN	_	_	3	obj	_	SpaceAfter=No|Translit=wénjiàn|LTranslit=wénjiàn
 7	前	前	ADP	_	_	3	mark	_	SpaceAfter=No|Translit=qián|LTranslit=qián
@@ -10747,7 +10747,7 @@
 # text = 我們是否必須如此草率、倉促地處理？
 # translit = wǒmenshìfǒubìxūrúcǐcǎolǜ,cāngcùdechùlǐ?
 1	我們	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
-2	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+2	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Interrogative-Reduced|CxnElt=2:Interrogative-Reduced.Clause
 3	否	否	ADV	_	_	2	conj	_	SpaceAfter=No|Translit=fǒu|LTranslit=fǒu
 4	必須	必須	AUX	_	_	10	aux	_	SpaceAfter=No|Translit=bìxū|LTranslit=bìxū
 5	如此	如此	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=rúcǐ|LTranslit=rúcǐ
@@ -10767,10 +10767,10 @@
 4	，	，	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 5	剛才	剛才	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=gāngcái|LTranslit=gāngcái
 6	也	也	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=yě|LTranslit=yě
-7	有	有	VERB	_	_	25	acl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-8	同事	同事	NOUN	_	_	7	obj	_	SpaceAfter=No|Translit=tóngshì|LTranslit=tóngshì
-9	提	提	VERB	_	_	8	acl	_	SpaceAfter=No|Translit=tí|LTranslit=tí
-10	到	到	VERB	_	_	9	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+7	有	有	VERB	_	_	25	acl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+8	同事	同事	NOUN	_	_	7	obj	_	SpaceAfter=No|Translit=tóngshì|LTranslit=tóngshì|CxnElt=7:Existential-HavePred.Pivot
+9	提	提	VERB	_	_	8	acl	_	SpaceAfter=No|Translit=tí|LTranslit=tí|Cxn=Resultative|CxnElt=9:Resultative.Event
+10	到	到	VERB	_	_	9	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=9:Resultative.ResultState
 11	，	，	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 12	就	就	ADP	_	_	25	case	_	SpaceAfter=No|Translit=jiù|LTranslit=jiù
 13	《	《	PUNCT	_	_	15	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -10792,8 +10792,8 @@
 29	認為	為	VERB	_	_	0	root	_	SpaceAfter=No|Translit=rènwèi|LTranslit=wèi
 30	當中	當中	NOUN	_	_	32	obl	_	SpaceAfter=No|Translit=dāngzhōng|LTranslit=dāngzhōng
 31	仍	仍	ADV	_	_	32	advmod	_	SpaceAfter=No|Translit=réng|LTranslit=réng
-32	有	有	VERB	_	_	29	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-33	爭議	爭議	NOUN	_	_	32	obj	_	SpaceAfter=No|Translit=zhēngyì|LTranslit=zhēngyì
+32	有	有	VERB	_	_	29	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+33	爭議	爭議	NOUN	_	_	32	obj	_	SpaceAfter=No|Translit=zhēngyì|LTranslit=zhēngyì|CxnElt=32:Existential-HavePred.Pivot
 34	。	。	PUNCT	_	_	29	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 836
@@ -10832,7 +10832,7 @@
 17	問題	問題	NOUN	_	_	20	obl	_	SpaceAfter=No|Translit=wèntí|LTranslit=wèntí
 18	，	，	PUNCT	_	_	17	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 19	我	我	PRON	_	_	20	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
-20	認為	為	VERB	_	_	0	root	_	SpaceAfter=No|Translit=rènwèi|LTranslit=wèi
+20	認為	為	VERB	_	_	0	root	_	SpaceAfter=No|Translit=rènwèi|LTranslit=wèi|Cxn=Interrogative-Reduced|CxnElt=20:Interrogative-Reduced.Clause
 21	在	在	ADP	_	_	23	mark	_	SpaceAfter=No|Translit=zài|LTranslit=zài
 22	未	未	ADV	_	_	23	advmod	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
 23	澄清	澄清	VERB	_	_	26	advcl	_	SpaceAfter=No|Translit=澄qīng|LTranslit=澄qīng
@@ -10887,10 +10887,10 @@
 # text = 其實有一件事情是否也屬於你的權力範圍，就是中止整個會議？
 # translit = qíshíyǒuyījiànshìqíngshìfǒuyěshǔyúnǐdequánlìfànwéi,jiùshìzhōngzhǐzhěnggèhuìyì?
 1	其實	其實	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=qíshí|LTranslit=qíshí
-2	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
+2	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred,Interrogative-Reduced|CxnElt=2:Interrogative-Reduced.Clause
 3	一	一	NUM	_	_	5	nummod	_	SpaceAfter=No|Translit=yī|LTranslit=yī
 4	件	件	NOUN	_	NounType=Clf	3	clf	_	SpaceAfter=No|Translit=jiàn|LTranslit=jiàn
-5	事情	事情	NOUN	_	_	2	obj	_	SpaceAfter=No|Translit=shìqíng|LTranslit=shìqíng
+5	事情	事情	NOUN	_	_	2	obj	_	SpaceAfter=No|Translit=shìqíng|LTranslit=shìqíng|CxnElt=2:Existential-HavePred.Pivot
 6	是	是	VERB	_	_	5	acl	_	SpaceAfter=No|Translit=shì|LTranslit=shì
 7	否	否	ADV	_	_	6	conj	_	SpaceAfter=No|Translit=fǒu|LTranslit=fǒu
 8	也	也	ADV	_	_	9	advmod	_	SpaceAfter=No|Translit=yě|LTranslit=yě
@@ -10918,7 +10918,7 @@
 6	風險	風險	NOUN	_	_	4	conj	_	SpaceAfter=No|Translit=fēngxiǎn|LTranslit=fēngxiǎn
 7	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 8	你	你	PRON	_	_	9	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-9	認為	為	VERB	_	_	0	root	_	SpaceAfter=No|Translit=rènwèi|LTranslit=wèi
+9	認為	為	VERB	_	_	0	root	_	SpaceAfter=No|Translit=rènwèi|LTranslit=wèi|Cxn=Interrogative-Reduced|CxnElt=9:Interrogative-Reduced.Clause
 10	今天	今天	NOUN	_	_	11	obl:tmod	_	SpaceAfter=No|Translit=jīntiān|LTranslit=jīntiān
 11	是	是	VERB	_	_	9	ccomp	_	SpaceAfter=No|Translit=shì|LTranslit=shì
 12	否	否	ADV	_	_	11	conj	_	SpaceAfter=No|Translit=fǒu|LTranslit=fǒu
@@ -10996,13 +10996,13 @@
 # translit = gāngcáiwǒliúyìdàozuìdàdewèntíshìshénme?
 1	剛才	剛才	ADV	_	_	9	advmod	_	SpaceAfter=No|Translit=gāngcái|LTranslit=gāngcái
 2	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
-3	留意	留意	VERB	_	_	7	acl	_	SpaceAfter=No|Translit=liúyì|LTranslit=liúyì
-4	到	到	VERB	_	_	3	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+3	留意	留意	VERB	_	_	7	acl	_	SpaceAfter=No|Translit=liúyì|LTranslit=liúyì|Cxn=Resultative|CxnElt=3:Resultative.Event
+4	到	到	VERB	_	_	3	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=3:Resultative.ResultState
 5	最大	最大	ADJ	_	_	7	amod	_	SpaceAfter=No|Translit=zuìdà|LTranslit=zuìdà
 6	的	的	PART	_	_	5	mark:rel	_	SpaceAfter=No|Translit=de|LTranslit=de
 7	問題	問題	NOUN	_	_	9	nsubj	_	SpaceAfter=No|Translit=wèntí|LTranslit=wèntí
 8	是	是	AUX	_	_	9	cop	_	SpaceAfter=No|Translit=shì|LTranslit=shì
-9	甚麼	甚麼	PRON	_	_	0	root	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme
+9	甚麼	甚麼	PRON	_	_	0	root	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|Cxn=Interrogative-WHInfo-Direct|CxnElt=9:Interrogative-WHInfo-Direct.Clause,9:Interrogative-WHInfo-Direct.WHWord
 10	？	？	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 847
@@ -11037,7 +11037,7 @@
 # sent_id = 849
 # text = 怎可能在尚未確定候選人的國籍便開展整個程式？
 # translit = zěnkěnéngzàishàngwèiquèdìnghouxuǎnréndeguójíbiànkāizhǎnzhěnggèchéngshì?
-1	怎	怎	ADV	_	_	11	advmod	_	SpaceAfter=No|Translit=zěn|LTranslit=zěn
+1	怎	怎	ADV	_	_	11	advmod	_	SpaceAfter=No|Translit=zěn|LTranslit=zěn|CxnElt=11:Interrogative-WHInfo-Direct.WHWord
 2	可能	可能	AUX	_	_	11	aux	_	SpaceAfter=No|Translit=kěnéng|LTranslit=kěnéng
 3	在	在	ADP	_	_	6	mark	_	SpaceAfter=No|Translit=zài|LTranslit=zài
 4	尚	尚	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=shàng|LTranslit=shàng
@@ -11047,7 +11047,7 @@
 8	的	的	PART	_	_	7	case	_	SpaceAfter=No|Translit=de|LTranslit=de
 9	國籍	國籍	NOUN	_	_	6	obj	_	SpaceAfter=No|Translit=guójí|LTranslit=guójí
 10	便	便	ADV	_	_	11	advmod	_	SpaceAfter=No|Translit=biàn|LTranslit=biàn
-11	開展	開展	VERB	_	_	0	root	_	SpaceAfter=No|Translit=kāizhǎn|LTranslit=kāizhǎn
+11	開展	開展	VERB	_	_	0	root	_	SpaceAfter=No|Translit=kāizhǎn|LTranslit=kāizhǎn|Cxn=Interrogative-WHInfo-Direct|CxnElt=11:Interrogative-WHInfo-Direct.Clause
 12	整個	整個	DET	_	_	13	det	_	SpaceAfter=No|Translit=zhěnggè|LTranslit=zhěnggè
 13	程式	程式	NOUN	_	_	11	obj	_	SpaceAfter=No|Translit=chéngshì|LTranslit=chéngshì
 14	？	？	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
@@ -11067,8 +11067,8 @@
 # text = 雖然有人指那些信件可證實其事，但都不過是口頭上的確認。
 # translit = suīrányǒurénzhǐnàxiēxìnjiànkězhèngshíqíshì,dàndōubùguòshìkǒutóushàngdequèrèn.
 1	雖然	雖然	SCONJ	_	_	2	mark	_	SpaceAfter=No|Translit=suīrán|LTranslit=suīrán
-2	有	有	VERB	_	_	18	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-3	人	人	NOUN	_	_	2	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén
+2	有	有	VERB	_	_	18	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+3	人	人	NOUN	_	_	2	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén|CxnElt=2:Existential-HavePred.Pivot
 4	指	指	VERB	_	_	2	xcomp	_	SpaceAfter=No|Translit=zhǐ|LTranslit=zhǐ
 5	那些	那些	DET	_	_	6	det	_	SpaceAfter=No|Translit=nàxiē|LTranslit=nàxiē
 6	信件	信件	NOUN	_	_	8	nsubj	_	SpaceAfter=No|Translit=xìnjiàn|LTranslit=xìnjiàn
@@ -11096,7 +11096,7 @@
 5	對	對	ADP	_	_	7	case	_	SpaceAfter=No|Translit=duì|LTranslit=duì
 6	整個	整個	DET	_	_	7	det	_	SpaceAfter=No|Translit=zhěnggè|LTranslit=zhěnggè
 7	選舉	選舉	NOUN	_	_	8	obl	_	SpaceAfter=No|Translit=xuǎnjǔ|LTranslit=xuǎnjǔ
-8	負責	負責	VERB	_	_	30	advcl	_	SpaceAfter=No|Translit=fùzé|LTranslit=fùzé
+8	負責	負責	VERB	_	_	30	advcl	_	SpaceAfter=No|Translit=fùzé|LTranslit=fùzé|CxnElt=30:Conditional-NegativeEpistemic.Protasis
 9	，	，	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 10	或	或	CCONJ	_	_	11	cc	_	SpaceAfter=No|Translit=huò|LTranslit=huò
 11	覺得	覺得	VERB	_	_	8	conj	_	SpaceAfter=No|Translit=juéde|LTranslit=juéde
@@ -11118,7 +11118,7 @@
 27	每	每	DET	_	_	30	det	_	SpaceAfter=No|Translit=měi|LTranslit=měi
 28	個	個	NOUN	_	NounType=Clf	27	clf	_	SpaceAfter=No|Translit=gè|LTranslit=gè
 29	程式	程式	NOUN	_	_	30	obl:patient	_	SpaceAfter=No|Translit=chéngshì|LTranslit=chéngshì
-30	做	做	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò
+30	做	做	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò|Cxn=Conditional-NegativeEpistemic|CxnElt=30:Conditional-NegativeEpistemic.Apodosis
 31	得	得	AUX	_	_	30	aux	_	SpaceAfter=No|Translit=de|LTranslit=de
 32	更	更	ADV	_	_	33	advmod	_	SpaceAfter=No|Translit=gèng|LTranslit=gèng
 33	嚴謹	嚴謹	ADJ	_	_	30	xcomp	_	SpaceAfter=No|Translit=yánjǐn|LTranslit=yánjǐn
@@ -11198,13 +11198,13 @@
 9	也	也	ADV	_	_	12	advmod	_	SpaceAfter=No|Translit=yě|LTranslit=yě
 10	不	不	ADV	_	_	12	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
 11	能	能	AUX	_	_	12	aux	_	SpaceAfter=No|Translit=néng|LTranslit=néng
-12	完成	完成	VERB	_	_	18	advcl	_	SpaceAfter=No|Translit=wánchéng|LTranslit=wánchéng
+12	完成	完成	VERB	_	_	18	advcl	_	SpaceAfter=No|Translit=wánchéng|LTranslit=wánchéng|CxnElt=18:Conditional-NeutralEpistemic.Protasis
 13	，	，	PUNCT	_	_	12	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 14	整個	整個	DET	_	_	15	det	_	SpaceAfter=No|Translit=zhěnggè|LTranslit=zhěnggè
 15	立法會	立法會	NOUN	_	_	18	nsubj	_	SpaceAfter=No|Translit=lìfǎhuì|LTranslit=lìfǎhuì
 16	不	不	ADV	_	_	18	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
 17	可能	可能	AUX	_	_	18	aux	_	SpaceAfter=No|Translit=kěnéng|LTranslit=kěnéng
-18	取信於人	取信於人	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǔxìnyúrén|LTranslit=qǔxìnyúrén
+18	取信於人	取信於人	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǔxìnyúrén|LTranslit=qǔxìnyúrén|Cxn=Conditional-NeutralEpistemic|CxnElt=18:Conditional-NeutralEpistemic.Apodosis
 19	。	。	PUNCT	_	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 856
@@ -11228,8 +11228,8 @@
 6	現在	現在	NOUN	_	_	9	obl:tmod	_	SpaceAfter=No|Translit=xiànzài|LTranslit=xiànzài
 7	尚	尚	ADV	_	_	9	advmod	_	SpaceAfter=No|Translit=shàng|LTranslit=shàng
 8	未	未	ADV	_	_	9	advmod	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
-9	弄	弄	VERB	_	_	0	root	_	SpaceAfter=No|Translit=nòng|LTranslit=nòng
-10	清楚	清楚	ADJ	_	_	9	compound:vv	_	SpaceAfter=No|Translit=qīngchu|LTranslit=qīngchu
+9	弄	弄	VERB	_	_	0	root	_	SpaceAfter=No|Translit=nòng|LTranslit=nòng|Cxn=Resultative|CxnElt=9:Resultative.Event
+10	清楚	清楚	ADJ	_	_	9	compound:vv	_	SpaceAfter=No|Translit=qīngchu|LTranslit=qīngchu|CxnElt=9:Resultative.ResultState
 11	多少	多少	DET	_	_	12	det	_	SpaceAfter=No|Translit=duōshǎo|LTranslit=duōshǎo
 12	議員	議員	NOUN	_	_	14	nsubj	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
 13	能夠	能夠	AUX	_	_	14	aux	_	SpaceAfter=No|Translit=nénggòu|LTranslit=nénggòu
@@ -11252,9 +11252,9 @@
 11	每	每	DET	_	_	13	det	_	SpaceAfter=No|Translit=měi|LTranslit=měi
 12	位	位	NOUN	_	NounType=Clf	11	clf	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
 13	議員	議員	NOUN	_	_	17	nsubj	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
-14	有	有	VERB	_	_	17	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
+14	有	有	VERB	_	_	17	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
 15	充足	充足	ADJ	_	_	16	amod	_	SpaceAfter=No|Translit=chōngzú|LTranslit=chōngzú
-16	機會	機會	NOUN	_	_	14	obj	_	SpaceAfter=No|Translit=jīhuì|LTranslit=jīhuì
+16	機會	機會	NOUN	_	_	14	obj	_	SpaceAfter=No|Translit=jīhuì|LTranslit=jīhuì|CxnElt=14:Existential-HavePred.Pivot
 17	完成	完成	VERB	_	_	10	ccomp	_	SpaceAfter=No|Translit=wánchéng|LTranslit=wánchéng
 18	宣誓	宣誓	VERB	_	_	19	acl	_	SpaceAfter=No|Translit=xuānshì|LTranslit=xuānshì
 19	程序	程序	NOUN	_	_	17	obj	_	SpaceAfter=No|Translit=chéngxù|LTranslit=chéngxù
@@ -11362,7 +11362,7 @@
 # translit = rúguǒdàjiāfānkàngāngcáilùyǐngpiànduàn,qíshísānwèiyìyuányǐwánzhěngdúwánshìcí.
 1	如果	如果	SCONJ	_	_	3	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
 2	大家	大家	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=dàjiā|LTranslit=dàjiā
-3	翻看	翻看	VERB	_	_	14	advcl	_	SpaceAfter=No|Translit=fānkàn|LTranslit=fānkàn
+3	翻看	翻看	VERB	_	_	14	advcl	_	SpaceAfter=No|Translit=fānkàn|LTranslit=fānkàn|CxnElt=14:Conditional-NeutralEpistemic.Protasis
 4	剛才	剛才	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=gāngcái|LTranslit=gāngcái
 5	錄影	錄影	VERB	_	_	6	acl	_	SpaceAfter=No|Translit=lùyǐng|LTranslit=lùyǐng
 6	片段	片段	NOUN	_	_	3	obj	_	SpaceAfter=No|Translit=piànduàn|LTranslit=piànduàn
@@ -11373,8 +11373,8 @@
 11	議員	議員	NOUN	_	_	14	nsubj	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
 12	已	已	ADV	_	_	14	advmod	_	SpaceAfter=No|Translit=yǐ|LTranslit=yǐ
 13	完整	完整	ADJ	_	_	14	advmod	_	SpaceAfter=No|Translit=wánzhěng|LTranslit=wánzhěng
-14	讀	讀	VERB	_	_	0	root	_	SpaceAfter=No|Translit=dú|LTranslit=dú
-15	完	完	VERB	_	_	14	compound:vv	_	SpaceAfter=No|Translit=wán|LTranslit=wán
+14	讀	讀	VERB	_	_	0	root	_	SpaceAfter=No|Translit=dú|LTranslit=dú|Cxn=Conditional-NeutralEpistemic,Resultative|CxnElt=14:Conditional-NeutralEpistemic.Apodosis,14:Resultative.Event
+15	完	完	VERB	_	_	14	compound:vv	_	SpaceAfter=No|Translit=wán|LTranslit=wán|CxnElt=14:Resultative.ResultState
 16	誓詞	誓詞	NOUN	_	_	14	obj	_	SpaceAfter=No|Translit=shìcí|LTranslit=shìcí
 17	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
@@ -11439,7 +11439,7 @@
 2	我們	我	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
 3	不	不	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
 4	先	先	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=xiān|LTranslit=xiān
-5	處理	處理	VERB	_	_	18	advcl	_	SpaceAfter=No|Translit=chùlǐ|LTranslit=chùlǐ
+5	處理	處理	VERB	_	_	18	advcl	_	SpaceAfter=No|Translit=chùlǐ|LTranslit=chùlǐ|CxnElt=18:Conditional-NeutralEpistemic.Protasis
 6	這些	這些	DET	_	_	7	det	_	SpaceAfter=No|Translit=zhèxiē|LTranslit=zhèxiē
 7	問題	問題	NOUN	_	_	5	obj	_	SpaceAfter=No|Translit=wèntí|LTranslit=wèntí
 8	，	，	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
@@ -11452,7 +11452,7 @@
 15	立法會	立法會	NOUN	_	_	18	nsubj	_	SpaceAfter=No|Translit=lìfǎhuì|LTranslit=lìfǎhuì
 16	便	便	ADV	_	_	18	advmod	_	SpaceAfter=No|Translit=biàn|LTranslit=biàn
 17	難以	難以	ADV	_	_	18	advmod	_	SpaceAfter=No|Translit=nányǐ|LTranslit=nányǐ
-18	取信於人	取信於人	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǔxìnyúrén|LTranslit=qǔxìnyúrén
+18	取信於人	取信於人	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǔxìnyúrén|LTranslit=qǔxìnyúrén|Cxn=Conditional-NeutralEpistemic|CxnElt=18:Conditional-NeutralEpistemic.Apodosis
 19	。	。	PUNCT	_	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 868
@@ -11465,10 +11465,10 @@
 5	，	，	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 6	包括	包括	VERB	_	_	4	acl	_	SpaceAfter=No|Translit=bāokuò|LTranslit=bāokuò
 7	眾多	眾多	DET	_	_	15	det	_	SpaceAfter=No|Translit=zhòngduō|LTranslit=zhòngduō
-8	有	有	VERB	_	_	12	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
+8	有	有	VERB	_	_	12	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
 9	廣大	廣大	ADJ	_	_	11	amod	_	SpaceAfter=No|Translit=guǎngdà|LTranslit=guǎngdà
 10	民意	民意	NOUN	_	_	11	compound	_	SpaceAfter=No|Translit=mínyì|LTranslit=mínyì
-11	基礎	基礎	NOUN	_	_	8	obj	_	SpaceAfter=No|Translit=jīchǔ|LTranslit=jīchǔ
+11	基礎	基礎	NOUN	_	_	8	obj	_	SpaceAfter=No|Translit=jīchǔ|LTranslit=jīchǔ|CxnElt=8:Existential-HavePred.Pivot
 12	支持	支持	VERB	_	_	15	acl	_	SpaceAfter=No|Translit=zhīchí|LTranslit=zhīchí
 13	的	的	PART	_	_	15	mark:rel	_	SpaceAfter=No|Translit=de|LTranslit=de
 14	直選	直選	NOUN	_	_	15	compound	_	SpaceAfter=No|Translit=zhíxuǎn|LTranslit=zhíxuǎn
@@ -11571,7 +11571,7 @@
 10	的	的	PART	_	_	9	case	_	SpaceAfter=No|Translit=de|LTranslit=de
 11	情況	情況	NOUN	_	_	13	obl	_	SpaceAfter=No|Translit=qíngkuàng|LTranslit=qíngkuàng
 12	下	下	ADP	_	_	11	case:loc	_	SpaceAfter=No|Translit=xià|LTranslit=xià
-13	進入	進入	VERB	_	_	22	advcl	_	SpaceAfter=No|Translit=jìnrù|LTranslit=jìnrù
+13	進入	進入	VERB	_	_	22	advcl	_	SpaceAfter=No|Translit=jìnrù|LTranslit=jìnrù|CxnElt=22:Conditional-NeutralEpistemic.Protasis
 14	選舉	選舉	VERB	_	_	17	acl	_	SpaceAfter=No|Translit=xuǎnjǔ|LTranslit=xuǎnjǔ
 15	立法會	立法會	NOUN	_	_	14	obj	_	SpaceAfter=No|Translit=lìfǎhuì|LTranslit=lìfǎhuì
 16	的	的	PART	_	_	14	mark:rel	_	SpaceAfter=No|Translit=de|LTranslit=de
@@ -11580,7 +11580,7 @@
 19	主席	主席	NOUN	_	_	22	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
 20	，	，	PUNCT	_	_	19	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 21	就	就	ADV	_	_	22	advmod	_	SpaceAfter=No|Translit=jiù|LTranslit=jiù
-22	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+22	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Conditional-NeutralEpistemic|CxnElt=22:Conditional-NeutralEpistemic.Apodosis
 23	讓	讓	VERB	_	_	22	ccomp	_	SpaceAfter=No|Translit=ràng|LTranslit=ràng
 24	梁君彥	梁君彥	PROPN	_	_	23	obj	_	SpaceAfter=No|Translit=liángjūn彥|LTranslit=liángjūn彥
 25	議員	議員	NOUN	_	_	24	flat	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
@@ -11700,17 +11700,17 @@
 9	的	的	PART	_	_	8	mark:rel	_	SpaceAfter=No|Translit=de|LTranslit=de
 10	情況	情況	NOUN	_	_	12	obl	_	SpaceAfter=No|Translit=qíngkuàng|LTranslit=qíngkuàng
 11	下	下	ADP	_	_	10	case:loc	_	SpaceAfter=No|Translit=xià|LTranslit=xià
-12	進行	進行	VERB	_	_	19	advcl	_	SpaceAfter=No|Translit=jìnxíng|LTranslit=jìnxíng
+12	進行	進行	VERB	_	_	19	advcl	_	SpaceAfter=No|Translit=jìnxíng|LTranslit=jìnxíng|CxnElt=19:Conditional-NeutralEpistemic.Protasis
 13	立法會	立法會	NOUN	_	_	15	compound	_	SpaceAfter=No|Translit=lìfǎhuì|LTranslit=lìfǎhuì
 14	主席	主席	NOUN	_	_	15	compound	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
 15	選舉	選舉	NOUN	_	_	12	obj	_	SpaceAfter=No|Translit=xuǎnjǔ|LTranslit=xuǎnjǔ
 16	，	，	PUNCT	_	_	12	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 17	香港	香港	PROPN	_	_	18	compound	_	SpaceAfter=No|Translit=xiānggǎng|LTranslit=xiānggǎng
 18	人	人	NOUN	_	_	19	nsubj	_	SpaceAfter=No|Translit=rén|LTranslit=rén
-19	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+19	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Conditional-NeutralEpistemic|CxnElt=19:Conditional-NeutralEpistemic.Apodosis
 20	會	會	AUX	_	_	21	aux	_	SpaceAfter=No|Translit=huì|LTranslit=huì
-21	看	看	VERB	_	_	19	ccomp	_	SpaceAfter=No|Translit=kàn|LTranslit=kàn
-22	到	到	VERB	_	_	21	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào
+21	看	看	VERB	_	_	19	ccomp	_	SpaceAfter=No|Translit=kàn|LTranslit=kàn|Cxn=Resultative|CxnElt=21:Resultative.Event
+22	到	到	VERB	_	_	21	compound:vv	_	SpaceAfter=No|Translit=dào|LTranslit=dào|CxnElt=21:Resultative.ResultState
 23	的	的	PART	_	_	21	discourse:sp	_	SpaceAfter=No|Translit=de|LTranslit=de
 24	。	。	PUNCT	_	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
@@ -11760,7 +11760,7 @@
 3	這	這	DET	_	_	6	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
 4	一	一	NUM	_	_	5	nummod	_	SpaceAfter=No|Translit=yī|LTranslit=yī
 5	刻	刻	NOUN	_	NounType=Clf	6	obl:tmod	_	SpaceAfter=No|Translit=kè|LTranslit=kè
-6	進行	進行	VERB	_	_	14	advcl	_	SpaceAfter=No|Translit=jìnxíng|LTranslit=jìnxíng
+6	進行	進行	VERB	_	_	14	advcl	_	SpaceAfter=No|Translit=jìnxíng|LTranslit=jìnxíng|CxnElt=14:Conditional-NeutralEpistemic.Protasis
 7	投票	投票	NOUN	_	_	6	obj	_	SpaceAfter=No|Translit=tóupiào|LTranslit=tóupiào
 8	，	，	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 9	當選者	當選者	NOUN	_	_	14	nsubj	_	SpaceAfter=No|Translit=dāngxuǎnzhě|LTranslit=dāngxuǎnzhě
@@ -11768,7 +11768,7 @@
 11	一	一	NUM	_	_	12	nummod	_	SpaceAfter=No|Translit=yī|LTranslit=yī
 12	刻	刻	NOUN	_	NounType=Clf	14	obl:tmod	_	SpaceAfter=No|Translit=kè|LTranslit=kè
 13	便	便	ADV	_	_	14	advmod	_	SpaceAfter=No|Translit=biàn|LTranslit=biàn
-14	成為	為	VERB	_	_	0	root	_	SpaceAfter=No|Translit=chéngwèi|LTranslit=wèi
+14	成為	為	VERB	_	_	0	root	_	SpaceAfter=No|Translit=chéngwèi|LTranslit=wèi|Cxn=Conditional-NeutralEpistemic|CxnElt=14:Conditional-NeutralEpistemic.Apodosis
 15	立法會	立法會	NOUN	_	_	16	compound	_	SpaceAfter=No|Translit=lìfǎhuì|LTranslit=lìfǎhuì
 16	主席	主席	NOUN	_	_	14	obj	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
 17	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
@@ -11831,7 +11831,7 @@
 5	議員	議員	NOUN	_	_	8	nsubj	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
 6	仍然	仍然	ADV	_	_	8	advmod	_	SpaceAfter=No|Translit=réngrán|LTranslit=réngrán
 7	無法	無法	ADV	_	_	8	advmod	_	SpaceAfter=No|Translit=wúfǎ|LTranslit=wúfǎ
-8	交	交	VERB	_	_	21	advcl	_	SpaceAfter=No|Translit=jiāo|LTranslit=jiāo
+8	交	交	VERB	_	_	21	advcl	_	SpaceAfter=No|Translit=jiāo|LTranslit=jiāo|CxnElt=21:Conditional-NeutralEpistemic.Protasis
 9	出	出	VERB	_	_	8	compound:dir	_	SpaceAfter=No|Translit=chū|LTranslit=chū
 10	蓋	蓋	VERB	_	_	16	acl	_	SpaceAfter=No|Translit=gài|LTranslit=gài
 11	有	有	VERB	_	_	10	conj	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
@@ -11844,7 +11844,7 @@
 18	他	他	PRON	_	_	21	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
 19	應該	應該	AUX	_	_	21	aux	_	SpaceAfter=No|Translit=yīnggāi|LTranslit=yīnggāi
 20	不	不	ADV	_	_	21	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-21	符合	符合	VERB	_	_	0	root	_	SpaceAfter=No|Translit=fúhé|LTranslit=fúhé
+21	符合	符合	VERB	_	_	0	root	_	SpaceAfter=No|Translit=fúhé|LTranslit=fúhé|Cxn=Conditional-NeutralEpistemic|CxnElt=21:Conditional-NeutralEpistemic.Apodosis
 22	參選	參選	VERB	_	_	23	acl	_	SpaceAfter=No|Translit=cānxuǎn|LTranslit=cānxuǎn
 23	資格	資格	NOUN	_	_	21	obj	_	SpaceAfter=No|Translit=zīgé|LTranslit=zīgé
 24	。	。	PUNCT	_	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
@@ -11869,7 +11869,7 @@
 15	議員	議員	NOUN	_	_	14	flat	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
 16	，	，	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 17	我們	我	PRON	_	_	18	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
-18	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+18	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Interrogative-Reduced|CxnElt=18:Interrogative-Reduced.Clause
 19	否	否	ADV	_	_	18	conj	_	SpaceAfter=No|Translit=fǒu|LTranslit=fǒu
 20	還	還	ADV	_	_	25	advmod	_	SpaceAfter=No|Translit=hái|LTranslit=hái
 21	要	要	AUX	_	_	23	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
@@ -11900,9 +11900,9 @@
 15	公眾	公眾	ADJ	_	_	16	amod	_	SpaceAfter=No|Translit=gōngzhòng|LTranslit=gōngzhòng
 16	利益	利益	NOUN	_	_	18	obl	_	SpaceAfter=No|Translit=lìyì|LTranslit=lìyì
 17	也	也	ADV	_	_	18	advmod	_	SpaceAfter=No|Translit=yě|LTranslit=yě
-18	有	有	VERB	_	_	3	conj	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
+18	有	有	VERB	_	_	3	conj	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
 19	莫大	莫大	ADJ	_	_	20	amod	_	SpaceAfter=No|Translit=mòdà|LTranslit=mòdà
-20	關係	關係	NOUN	_	_	18	obj	_	SpaceAfter=No|Translit=guānxì|LTranslit=guānxì
+20	關係	關係	NOUN	_	_	18	obj	_	SpaceAfter=No|Translit=guānxì|LTranslit=guānxì|CxnElt=18:Existential-HavePred.Pivot
 21	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 888
@@ -11928,7 +11928,7 @@
 2	梁君彥	梁君彥	PROPN	_	_	5	nsubj	_	SpaceAfter=No|Translit=liángjūn彥|LTranslit=liángjūn彥
 3	議員	議員	NOUN	_	_	2	flat	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
 4	無法	無法	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=wúfǎ|LTranslit=wúfǎ
-5	交	交	VERB	_	_	13	advcl	_	SpaceAfter=No|Translit=jiāo|LTranslit=jiāo
+5	交	交	VERB	_	_	13	advcl	_	SpaceAfter=No|Translit=jiāo|LTranslit=jiāo|CxnElt=13:Conditional-NeutralEpistemic.Protasis
 6	出	出	VERB	_	_	5	compound:dir	_	SpaceAfter=No|Translit=chū|LTranslit=chū
 7	文件	文件	NOUN	_	_	8	compound	_	SpaceAfter=No|Translit=wénjiàn|LTranslit=wénjiàn
 8	正本	正本	NOUN	_	_	5	obj	_	SpaceAfter=No|Translit=zhèngběn|LTranslit=zhèngběn
@@ -11936,7 +11936,7 @@
 10	他	他	PRON	_	_	13	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
 11	應該	應該	AUX	_	_	13	aux	_	SpaceAfter=No|Translit=yīnggāi|LTranslit=yīnggāi
 12	不	不	ADV	_	_	13	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-13	符合	符合	VERB	_	_	0	root	_	SpaceAfter=No|Translit=fúhé|LTranslit=fúhé
+13	符合	符合	VERB	_	_	0	root	_	SpaceAfter=No|Translit=fúhé|LTranslit=fúhé|Cxn=Conditional-NeutralEpistemic|CxnElt=13:Conditional-NeutralEpistemic.Apodosis
 14	參選	參選	VERB	_	_	15	acl	_	SpaceAfter=No|Translit=cānxuǎn|LTranslit=cānxuǎn
 15	資格	資格	NOUN	_	_	13	obj	_	SpaceAfter=No|Translit=zīgé|LTranslit=zīgé
 16	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
@@ -12057,11 +12057,11 @@
 4	這	這	PRON	_	_	7	nsubj	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
 5	是	是	AUX	_	_	7	cop	_	SpaceAfter=No|Translit=shì|LTranslit=shì
 6	正式	正式	ADJ	_	_	7	amod	_	SpaceAfter=No|Translit=zhèngshì|LTranslit=zhèngshì
-7	會議	會議	NOUN	_	_	11	advcl	_	SpaceAfter=No|Translit=huìyì|LTranslit=huìyì
+7	會議	會議	NOUN	_	_	11	advcl	_	SpaceAfter=No|Translit=huìyì|LTranslit=huìyì|CxnElt=11:Conditional-NeutralEpistemic.Protasis
 8	，	，	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 9	梁頌恒	梁頌恒	PROPN	_	_	11	nsubj	_	SpaceAfter=No|Translit=liángsònghéng|LTranslit=liángsònghéng
 10	議員	議員	NOUN	_	_	9	flat	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
-11	沒有	有	VERB	_	Polarity=Neg	0	root	_	SpaceAfter=No|Translit=méiyǒu|LTranslit=yǒu
+11	沒有	有	VERB	_	Polarity=Neg	0	root	_	SpaceAfter=No|Translit=méiyǒu|LTranslit=yǒu|Cxn=Conditional-NeutralEpistemic|CxnElt=11:Conditional-NeutralEpistemic.Apodosis
 12	資格	資格	NOUN	_	_	11	obj	_	SpaceAfter=No|Translit=zīgé|LTranslit=zīgé
 13	參加	參加	VERB	_	_	12	acl	_	SpaceAfter=No|Translit=cānjiā|LTranslit=cānjiā
 14	這個	這個	DET	_	_	15	det	_	SpaceAfter=No|Translit=zhègè|LTranslit=zhègè
@@ -12087,11 +12087,11 @@
 # translit = wǒxiǎngwènwǒxiànzàijiūjìngyǒuméiyǒuquáncānjiāzhègèhuìyì?
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 2	想	想	AUX	_	_	3	aux	_	SpaceAfter=No|Translit=xiǎng|LTranslit=xiǎng
-3	問	問	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wèn|LTranslit=wèn
+3	問	問	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wèn|LTranslit=wèn|Cxn=Interrogative-Reduced|CxnElt=3:Interrogative-Reduced.Clause
 4	我	我	PRON	_	_	7	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 5	現在	現在	NOUN	_	_	7	obl:tmod	_	SpaceAfter=No|Translit=xiànzài|LTranslit=xiànzài
 6	究竟	究竟	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=jiūjìng|LTranslit=jiūjìng
-7	有	有	VERB	_	_	3	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
+7	有	有	VERB	_	_	3	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Interrogative-Polar-Direct|CxnElt=7:Interrogative-Polar-Direct.Clause
 8	沒	沒	ADV	_	_	9	advmod	_	SpaceAfter=No|Translit=méi|LTranslit=méi
 9	有	有	VERB	_	_	7	conj	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
 10	權	權	NOUN	_	_	7	obj	_	SpaceAfter=No|Translit=quán|LTranslit=quán
@@ -12161,8 +12161,8 @@
 13	次	次	NOUN	_	NounType=Clf	12	clf	_	SpaceAfter=No|Translit=cì|LTranslit=cì
 14	會議	會議	NOUN	_	_	6	appos	_	SpaceAfter=No|Translit=huìyì|LTranslit=huìyì
 15	》	》	PUNCT	_	_	14	punct	_	SpaceAfter=No|Translit=»|LTranslit=»
-16	訂	訂	VERB	_	_	0	root	_	SpaceAfter=No|Translit=dìng|LTranslit=dìng
-17	明	明	ADJ	_	_	16	compound:vv	_	SpaceAfter=No|Translit=míng|LTranslit=míng
+16	訂	訂	VERB	_	_	0	root	_	SpaceAfter=No|Translit=dìng|LTranslit=dìng|Cxn=Resultative|CxnElt=16:Resultative.Event
+17	明	明	ADJ	_	_	16	compound:vv	_	SpaceAfter=No|Translit=míng|LTranslit=míng|CxnElt=16:Resultative.ResultState
 18	……	……	PUNCT	_	_	16	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 901
@@ -12300,9 +12300,9 @@
 # text = 試問怎能進入第二款選舉立法會主席的程序？
 # translit = shìwènzěnnéngjìnrùdì'èrkuǎnxuǎnjǔlìfǎhuìzhǔxídechéngxù?
 1	試問	試問	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=shìwèn|LTranslit=shìwèn
-2	怎	怎	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=zěn|LTranslit=zěn
+2	怎	怎	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=zěn|LTranslit=zěn|CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 3	能	能	AUX	_	_	4	aux	_	SpaceAfter=No|Translit=néng|LTranslit=néng
-4	進入	進入	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jìnrù|LTranslit=jìnrù
+4	進入	進入	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jìnrù|LTranslit=jìnrù|Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	第二	第二	ADJ	_	_	6	amod	_	SpaceAfter=No|Translit=dì'èr|LTranslit=dì'èr
 6	款	款	NOUN	_	NounType=Clf	11	compound	_	SpaceAfter=No|Translit=kuǎn|LTranslit=kuǎn
 7	選舉	選舉	VERB	_	_	11	acl	_	SpaceAfter=No|Translit=xuǎnjǔ|LTranslit=xuǎnjǔ
@@ -12364,7 +12364,7 @@
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 3	如果	如果	SCONJ	_	_	5	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
 4	你	你	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-5	確認	確認	VERB	_	_	17	advcl	_	SpaceAfter=No|Translit=quèrèn|LTranslit=quèrèn
+5	確認	確認	VERB	_	_	17	advcl	_	SpaceAfter=No|Translit=quèrèn|LTranslit=quèrèn|CxnElt=17:Conditional-NeutralEpistemic.Protasis
 6	這	這	PRON	_	_	11	nsubj	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
 7	是	是	AUX	_	_	11	cop	_	SpaceAfter=No|Translit=shì|LTranslit=shì
 8	一	一	NUM	_	_	11	nummod	_	SpaceAfter=No|Translit=yī|LTranslit=yī
@@ -12376,7 +12376,7 @@
 14	這樣	這樣	ADV	_	_	15	advmod	_	SpaceAfter=No|Translit=zhèyàng|LTranslit=zhèyàng
 15	做	做	VERB	_	_	17	advcl	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò
 16	嚴重	嚴重	ADJ	_	_	17	advmod	_	SpaceAfter=No|Translit=yánzhòng|LTranslit=yánzhòng
-17	違反	違反	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wéifǎn|LTranslit=wéifǎn
+17	違反	違反	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wéifǎn|LTranslit=wéifǎn|Cxn=Conditional-NeutralEpistemic|CxnElt=17:Conditional-NeutralEpistemic.Apodosis
 18	了	了	AUX	_	_	17	aux	_	SpaceAfter=No|Translit=le|LTranslit=le
 19	《	《	PUNCT	_	_	21	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
 20	議事	議事	NOUN	_	_	21	compound	_	SpaceAfter=No|Translit=yìshì|LTranslit=yìshì
@@ -12491,7 +12491,7 @@
 1	但	但	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
 2	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 3	想	想	AUX	_	_	4	aux	_	SpaceAfter=No|Translit=xiǎng|LTranslit=xiǎng
-4	知道	知道	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhīdào|LTranslit=zhīdào
+4	知道	知道	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhīdào|LTranslit=zhīdào|Cxn=Interrogative-Reduced|CxnElt=4:Interrogative-Reduced.Clause
 5	，	，	PUNCT	_	_	10	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 6	你	你	PRON	_	_	8	nmod	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 7	的	的	PART	_	_	6	case	_	SpaceAfter=No|Translit=de|LTranslit=de
@@ -12513,7 +12513,7 @@
 # translit = rúguǒnǐrènwèitādexuānshìyǒuxiào'érzhǔnxǔtāfāyán,nǐkěyǐcǐwèijīchǔzuòchūjuédìng.
 1	如果	如果	SCONJ	_	_	3	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
 2	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-3	認為	為	VERB	_	_	19	advcl	_	SpaceAfter=No|Translit=rènwèi|LTranslit=wèi
+3	認為	為	VERB	_	_	19	advcl	_	SpaceAfter=No|Translit=rènwèi|LTranslit=wèi|CxnElt=19:Conditional-NeutralEpistemic.Protasis
 4	他	他	PRON	_	_	6	nmod	_	SpaceAfter=No|Translit=tā|LTranslit=tā
 5	的	的	PART	_	_	4	case	_	SpaceAfter=No|Translit=de|LTranslit=de
 6	宣誓	宣誓	NOUN	_	_	7	nsubj	_	SpaceAfter=No|Translit=xuānshì|LTranslit=xuānshì
@@ -12529,7 +12529,7 @@
 16	此	此	PRON	_	_	17	obl	_	SpaceAfter=No|Translit=cǐ|LTranslit=cǐ
 17	為	為	VERB	_	_	19	advcl	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
 18	基礎	基礎	NOUN	_	_	17	obj	_	SpaceAfter=No|Translit=jīchǔ|LTranslit=jīchǔ
-19	作出	作出	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zuòchū|LTranslit=zuòchū
+19	作出	作出	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zuòchū|LTranslit=zuòchū|Cxn=Conditional-NeutralEpistemic|CxnElt=19:Conditional-NeutralEpistemic.Apodosis
 20	決定	決定	NOUN	_	_	19	obj	_	SpaceAfter=No|Translit=juédìng|LTranslit=juédìng
 21	。	。	PUNCT	_	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
@@ -12539,7 +12539,7 @@
 1	但	但	ADV	_	_	18	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
 2	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
 3	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
-4	同意	同意	VERB	_	_	18	advcl	_	SpaceAfter=No|Translit=tóngyì|LTranslit=tóngyì
+4	同意	同意	VERB	_	_	18	advcl	_	SpaceAfter=No|Translit=tóngyì|LTranslit=tóngyì|CxnElt=18:Conditional-NeutralEpistemic.Protasis
 5	有關	有關	ADJ	_	_	6	amod	_	SpaceAfter=No|Translit=yǒuguān|LTranslit=yǒuguān
 6	宣誓	宣誓	NOUN	_	_	8	nsubj	_	SpaceAfter=No|Translit=xuānshì|LTranslit=xuānshì
 7	不	不	ADV	_	_	8	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -12553,7 +12553,7 @@
 15	做	做	VERB	_	_	18	advcl	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò
 16	便	便	ADV	_	_	18	advmod	_	SpaceAfter=No|Translit=biàn|LTranslit=biàn
 17	嚴重	嚴重	ADV	_	_	18	advmod	_	SpaceAfter=No|Translit=yánzhòng|LTranslit=yánzhòng
-18	違反	違反	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wéifǎn|LTranslit=wéifǎn
+18	違反	違反	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wéifǎn|LTranslit=wéifǎn|Cxn=Conditional-NeutralEpistemic|CxnElt=18:Conditional-NeutralEpistemic.Apodosis
 19	了	了	AUX	_	_	18	aux	_	SpaceAfter=No|Translit=le|LTranslit=le
 20	《	《	PUNCT	_	_	22	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
 21	議事	議事	VERB	_	_	22	acl	_	SpaceAfter=No|Translit=yìshì|LTranslit=yìshì
@@ -12634,7 +12634,7 @@
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 2	又	又	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=yòu|LTranslit=yòu
 3	如何	如何	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=rúhé|LTranslit=rúhé
-4	解釋	解釋	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jiěshì|LTranslit=jiěshì
+4	解釋	解釋	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jiěshì|LTranslit=jiěshì|Cxn=Interrogative-Reduced|CxnElt=4:Interrogative-Reduced.Clause
 5	呢	呢	PART	_	_	4	discourse:sp	_	SpaceAfter=No|Translit=ne|LTranslit=ne
 6	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -12673,8 +12673,8 @@
 3	你	你	PRON	_	_	6	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 4	不	不	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
 5	要	要	AUX	_	_	6	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
-6	搞	搞	VERB	_	_	0	root	_	SpaceAfter=No|Translit=gǎo|LTranslit=gǎo
-7	錯	錯	ADJ	_	_	6	compound:vv	_	SpaceAfter=No|Translit=cuò|LTranslit=cuò
+6	搞	搞	VERB	_	_	0	root	_	SpaceAfter=No|Translit=gǎo|LTranslit=gǎo|Cxn=Resultative|CxnElt=6:Resultative.Event
+7	錯	錯	ADJ	_	_	6	compound:vv	_	SpaceAfter=No|Translit=cuò|LTranslit=cuò|CxnElt=6:Resultative.ResultState
 8	這個	這個	DET	_	_	9	det	_	SpaceAfter=No|Translit=zhègè|LTranslit=zhègè
 9	邏輯	邏輯	NOUN	_	_	6	obj	_	SpaceAfter=No|Translit=luóji|LTranslit=luóji
 10	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
@@ -12696,8 +12696,8 @@
 3	在於	在於	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zàiyú|LTranslit=zàiyú
 4	尚	尚	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=shàng|LTranslit=shàng
 5	未	未	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
-6	有	有	VERB	_	_	3	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-7	人	人	NOUN	_	_	6	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén
+6	有	有	VERB	_	_	3	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+7	人	人	NOUN	_	_	6	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén|CxnElt=6:Existential-HavePred.Pivot
 8	取消	取消	VERB	_	_	7	acl	_	SpaceAfter=No|Translit=qǔxiāo|LTranslit=qǔxiāo
 9	他	他	PRON	_	_	11	nmod	_	SpaceAfter=No|Translit=tā|LTranslit=tā
 10	的	的	PART	_	_	9	case	_	SpaceAfter=No|Translit=de|LTranslit=de
@@ -12720,8 +12720,8 @@
 6	就座	就座	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jiùzuò|LTranslit=jiùzuò
 7	，	，	PUNCT	_	_	20	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 8	沒	沒	ADV	_	_	9	advmod	_	SpaceAfter=No|Translit=méi|LTranslit=méi
-9	有	有	VERB	_	_	20	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-10	人	人	NOUN	_	_	9	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén
+9	有	有	VERB	_	_	20	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+10	人	人	NOUN	_	_	9	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén|CxnElt=9:Existential-HavePred.Pivot
 11	取消	取消	VERB	_	_	9	acl	_	SpaceAfter=No|Translit=qǔxiāo|LTranslit=qǔxiāo
 12	你	你	PRON	_	_	14	nmod	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 13	的	的	PART	_	_	12	case	_	SpaceAfter=No|Translit=de|LTranslit=de
@@ -12786,8 +12786,8 @@
 12	宣誓	宣誓	NOUN	_	_	8	obj	_	SpaceAfter=No|Translit=xuānshì|LTranslit=xuānshì
 13	，	，	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 14	才	才	ADV	_	_	17	advmod	_	SpaceAfter=No|Translit=cái|LTranslit=cái
-15	有	有	VERB	_	_	17	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-16	資格	資格	NOUN	_	_	15	obj	_	SpaceAfter=No|Translit=zīgé|LTranslit=zīgé
+15	有	有	VERB	_	_	17	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+16	資格	資格	NOUN	_	_	15	obj	_	SpaceAfter=No|Translit=zīgé|LTranslit=zīgé|CxnElt=15:Existential-HavePred.Pivot
 17	進入	進入	VERB	_	_	4	ccomp	_	SpaceAfter=No|Translit=jìnrù|LTranslit=jìnrù
 18	第二	第二	ADJ	_	_	19	amod	_	SpaceAfter=No|Translit=dì'èr|LTranslit=dì'èr
 19	階段	階段	NOUN	_	_	17	obj	_	SpaceAfter=No|Translit=jiēduàn|LTranslit=jiēduàn
@@ -12821,8 +12821,8 @@
 10	尚未	尚未	ADV	_	_	11	advmod	_	SpaceAfter=No|Translit=shàngwèi|LTranslit=shàngwèi
 11	宣誓	宣誓	VERB	_	_	17	advcl	_	SpaceAfter=No|Translit=xuānshì|LTranslit=xuānshì
 12	已	已	ADV	_	_	13	advmod	_	SpaceAfter=No|Translit=yǐ|LTranslit=yǐ
-13	有	有	VERB	_	_	3	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-14	資格	資格	NOUN	_	_	13	obj	_	SpaceAfter=No|Translit=zīgé|LTranslit=zīgé
+13	有	有	VERB	_	_	3	ccomp	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+14	資格	資格	NOUN	_	_	13	obj	_	SpaceAfter=No|Translit=zīgé|LTranslit=zīgé|CxnElt=13:Existential-HavePred.Pivot
 15	在	在	ADP	_	_	16	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
 16	會議廳	會議廳	NOUN	_	_	17	obl	_	SpaceAfter=No|Translit=huìyìtīng|LTranslit=huìyìtīng
 17	就座	就座	VERB	_	_	14	acl	_	SpaceAfter=No|Translit=jiùzuò|LTranslit=jiùzuò
@@ -12880,7 +12880,7 @@
 1	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
 2	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 3	仍	仍	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=réng|LTranslit=réng
-4	視	視	VERB	_	_	18	advcl	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+4	視	視	VERB	_	_	18	advcl	_	SpaceAfter=No|Translit=shì|LTranslit=shì|CxnElt=18:Conditional-NeutralEpistemic.Protasis
 5	我	我	PRON	_	_	4	obj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 6	為	為	AUX	_	_	7	cop	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
 7	主席	主席	NOUN	_	_	4	ccomp	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -12894,7 +12894,7 @@
 15	你	你	PRON	_	_	18	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 16	便	便	ADV	_	_	18	advmod	_	SpaceAfter=No|Translit=biàn|LTranslit=biàn
 17	要	要	AUX	_	_	18	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
-18	接受	接受	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jiēshòu|LTranslit=jiēshòu
+18	接受	接受	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jiēshòu|LTranslit=jiēshòu|Cxn=Conditional-NeutralEpistemic|CxnElt=18:Conditional-NeutralEpistemic.Apodosis
 19	我	我	PRON	_	_	21	nmod	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 20	的	的	PART	_	_	19	case	_	SpaceAfter=No|Translit=de|LTranslit=de
 21	決定	決定	NOUN	_	_	18	obj	_	SpaceAfter=No|Translit=juédìng|LTranslit=juédìng
@@ -12929,7 +12929,7 @@
 4	你	你	PRON	_	_	7	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 5	是否	是否	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=shìfǒu|LTranslit=shìfǒu
 6	要	要	AUX	_	_	7	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
-7	繼續	繼續	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jìxù|LTranslit=jìxù
+7	繼續	繼續	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jìxù|LTranslit=jìxù|Cxn=Interrogative-Reduced|CxnElt=7:Interrogative-Reduced.Clause
 8	發言	發言	VERB	_	_	7	xcomp	_	SpaceAfter=No|Translit=fāyán|LTranslit=fāyán
 9	？	？	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -13018,8 +13018,8 @@
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 2	根本	根本	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=gēnběn|LTranslit=gēnběn
 3	沒	沒	ADV	_	_	6	advcl	_	SpaceAfter=No|Translit=méi|LTranslit=méi
-4	有	有	VERB	_	_	6	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
-5	power	power	NOUN	_	_	4	obj	_	SpaceAfter=No|Translit=power|LTranslit=power
+4	有	有	VERB	_	_	6	advcl	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
+5	power	power	NOUN	_	_	4	obj	_	SpaceAfter=No|Translit=power|LTranslit=power|CxnElt=4:Existential-HavePred.Pivot
 6	作出	作出	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zuòchū|LTranslit=zuòchū
 7	這	這	DET	_	_	8	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
 8	決定	決定	NOUN	_	_	6	obj	_	SpaceAfter=No|Translit=juédìng|LTranslit=juédìng
@@ -13079,7 +13079,7 @@
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 2	是否	是否	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=shìfǒu|LTranslit=shìfǒu
 3	要	要	AUX	_	_	4	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
-4	作出	作出	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zuòchū|LTranslit=zuòchū
+4	作出	作出	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zuòchū|LTranslit=zuòchū|Cxn=Interrogative-Reduced|CxnElt=4:Interrogative-Reduced.Clause
 5	違反	違反	VERB	_	_	4	ccomp	_	SpaceAfter=No|Translit=wéifǎn|LTranslit=wéifǎn
 6	《	《	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
 7	議事	議事	VERB	_	_	8	acl	_	SpaceAfter=No|Translit=yìshì|LTranslit=yìshì
@@ -13104,7 +13104,7 @@
 1	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
 2	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 3	不	不	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-4	同意	同意	VERB	_	_	13	advcl	_	SpaceAfter=No|Translit=tóngyì|LTranslit=tóngyì
+4	同意	同意	VERB	_	_	13	advcl	_	SpaceAfter=No|Translit=tóngyì|LTranslit=tóngyì|CxnElt=13:Conditional-NeutralEpistemic.Protasis
 5	我	我	PRON	_	_	7	nmod	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 6	的	的	PART	_	_	5	case	_	SpaceAfter=No|Translit=de|LTranslit=de
 7	決定	決定	NOUN	_	_	4	obj	_	SpaceAfter=No|Translit=juédìng|LTranslit=juédìng
@@ -13113,7 +13113,7 @@
 10	向	向	ADP	_	_	11	case	_	SpaceAfter=No|Translit=xiàng|LTranslit=xiàng
 11	法庭	法庭	NOUN	_	_	12	obl	_	SpaceAfter=No|Translit=fǎtíng|LTranslit=fǎtíng
 12	提出	提出	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tíchū|LTranslit=tíchū
-13	質疑	質疑	NOUN	_	_	12	obj	_	SpaceAfter=No|Translit=zhìyí|LTranslit=zhìyí
+13	質疑	質疑	NOUN	_	_	12	obj	_	SpaceAfter=No|Translit=zhìyí|LTranslit=zhìyí|Cxn=Conditional-NeutralEpistemic|CxnElt=13:Conditional-NeutralEpistemic.Apodosis
 14	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 953
@@ -13126,7 +13126,7 @@
 5	不	不	ADV	_	_	8	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
 6	跟	跟	ADP	_	_	7	case	_	SpaceAfter=No|Translit=gēn|LTranslit=gēn
 7	他們	他	PRON	_	_	8	obl	_	SpaceAfter=No|Translit=tāmen|LTranslit=tā
-8	說	說	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shuō|LTranslit=shuō
+8	說	說	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shuō|LTranslit=shuō|Cxn=Interrogative-Reduced|CxnElt=8:Interrogative-Reduced.Clause
 9	？	？	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 954
@@ -13135,7 +13135,7 @@
 1	為何	為何	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=wèihé|LTranslit=wèihé
 2	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 3	不	不	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-4	叫	叫	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jiào|LTranslit=jiào
+4	叫	叫	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jiào|LTranslit=jiào|Cxn=Interrogative-Reduced|CxnElt=4:Interrogative-Reduced.Clause
 5	他們	他	PRON	_	_	4	obj	_	SpaceAfter=No|Translit=tāmen|LTranslit=tā
 6	向	向	ADP	_	_	7	case	_	SpaceAfter=No|Translit=xiàng|LTranslit=xiàng
 7	法庭	法庭	NOUN	_	_	8	obl	_	SpaceAfter=No|Translit=fǎtíng|LTranslit=fǎtíng
@@ -13152,7 +13152,7 @@
 # translit = wǒbùshìyǐjuédìnglema?
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
 2	不	不	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
-3	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
+3	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	已	已	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=yǐ|LTranslit=yǐ
 5	決定	決定	VERB	_	_	3	ccomp	_	SpaceAfter=No|Translit=juédìng|LTranslit=juédìng
 6	了	了	AUX	_	_	5	aux	_	SpaceAfter=No|Translit=le|LTranslit=le
@@ -13169,7 +13169,7 @@
 5	祇	祇	ADV	_	_	8	advmod	_	SpaceAfter=No|Translit=祇|LTranslit=祇
 6	對	對	ADP	_	_	7	case	_	SpaceAfter=No|Translit=duì|LTranslit=duì
 7	我	我	PRON	_	_	8	obl	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
-8	說	說	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shuō|LTranslit=shuō
+8	說	說	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shuō|LTranslit=shuō|Cxn=Interrogative-Reduced|CxnElt=8:Interrogative-Reduced.Clause
 9	，	，	PUNCT	_	_	17	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 10	卻	卻	CCONJ	_	_	17	cc	_	SpaceAfter=No|Translit=què|LTranslit=què
 11	不	不	ADV	_	_	14	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -13201,7 +13201,7 @@
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 3	為何	為何	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=wèihé|LTranslit=wèihé
 4	要	要	AUX	_	_	5	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
-5	這樣	這樣	ADV	_	_	0	root	_	SpaceAfter=No|Translit=zhèyàng|LTranslit=zhèyàng
+5	這樣	這樣	ADV	_	_	0	root	_	SpaceAfter=No|Translit=zhèyàng|LTranslit=zhèyàng|Cxn=Interrogative-Reduced|CxnElt=5:Interrogative-Reduced.Clause
 6	呢	呢	PART	_	_	5	discourse:sp	_	SpaceAfter=No|Translit=ne|LTranslit=ne
 7	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -13210,7 +13210,7 @@
 # translit = nǐkěfǒubǎochízhōnglìhégōngzhèng,'ànzhào«yìshìguīzé»láibànshì?
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 2	可否	可否	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=kěfǒu|LTranslit=kěfǒu
-3	保持	保持	VERB	_	_	0	root	_	SpaceAfter=No|Translit=bǎochí|LTranslit=bǎochí
+3	保持	保持	VERB	_	_	0	root	_	SpaceAfter=No|Translit=bǎochí|LTranslit=bǎochí|Cxn=Interrogative-Reduced|CxnElt=3:Interrogative-Reduced.Clause
 4	中立	中立	NOUN	_	_	3	obj	_	SpaceAfter=No|Translit=zhōnglì|LTranslit=zhōnglì
 5	和	和	CCONJ	_	_	6	cc	_	SpaceAfter=No|Translit=hé|LTranslit=hé
 6	公正	公正	NOUN	_	_	4	conj	_	SpaceAfter=No|Translit=gōngzhèng|LTranslit=gōngzhèng
@@ -13411,10 +13411,10 @@
 # translit = bùyīngyǒuwǔgèrénchuí簾tīngzhèng.
 1	不	不	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
 2	應	應	AUX	_	_	3	aux	_	SpaceAfter=No|Translit=yīng|LTranslit=yīng
-3	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
+3	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
 4	五	五	NUM	_	_	6	nummod	_	SpaceAfter=No|Translit=wǔ|LTranslit=wǔ
 5	個	個	NOUN	_	NounType=Clf	4	clf	_	SpaceAfter=No|Translit=gè|LTranslit=gè
-6	人	人	NOUN	_	_	3	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén
+6	人	人	NOUN	_	_	3	obj	_	SpaceAfter=No|Translit=rén|LTranslit=rén|CxnElt=3:Existential-HavePred.Pivot
 7	垂簾聽政	垂簾聽政	VERB	_	_	6	acl	_	SpaceAfter=No|Translit=chuí簾tīngzhèng|LTranslit=chuí簾tīngzhèng
 8	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
@@ -13429,7 +13429,7 @@
 6	來	來	SCONJ	_	_	7	mark	_	SpaceAfter=No|Translit=lái|LTranslit=lái
 7	保護	保護	VERB	_	_	3	advcl	_	SpaceAfter=No|Translit=bǎohù|LTranslit=bǎohù
 8	，	，	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
-9	對	對	ADJ	_	_	3	parataxis	_	SpaceAfter=No|Translit=duì|LTranslit=duì
+9	對	對	ADJ	_	_	3	parataxis	_	SpaceAfter=No|Translit=duì|LTranslit=duì|Cxn=Interrogative-Polar-Direct|CxnElt=9:Interrogative-Polar-Direct.Clause
 10	嗎	嗎	PART	_	_	9	discourse:sp	_	SpaceAfter=No|Translit=ma|LTranslit=ma
 11	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
@@ -13498,8 +13498,8 @@
 2	第四十二	第四十二	ADJ	_	_	5	nsubj	_	SpaceAfter=No|Translit=dìsìshí'èr|LTranslit=dìsìshí'èr
 3	條	條	NOUN	_	NounType=Clf	2	clf	_	SpaceAfter=No|Translit=tiáo|LTranslit=tiáo
 4	清楚	清楚	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=qīngchu|LTranslit=qīngchu
-5	訂	訂	VERB	_	_	0	root	_	SpaceAfter=No|Translit=dìng|LTranslit=dìng
-6	明	明	ADJ	_	_	5	compound:vv	_	SpaceAfter=No|Translit=míng|LTranslit=míng
+5	訂	訂	VERB	_	_	0	root	_	SpaceAfter=No|Translit=dìng|LTranslit=dìng|Cxn=Resultative|CxnElt=5:Resultative.Event
+6	明	明	ADJ	_	_	5	compound:vv	_	SpaceAfter=No|Translit=míng|LTranslit=míng|CxnElt=5:Resultative.ResultState
 7	……	……	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 980
@@ -13580,8 +13580,8 @@
 2	議員	議員	NOUN	_	_	1	flat	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
 3	尚	尚	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=shàng|LTranslit=shàng
 4	未	未	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
-5	說	說	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shuō|LTranslit=shuō
-6	完	完	VERB	_	_	5	compound:vv	_	SpaceAfter=No|Translit=wán|LTranslit=wán
+5	說	說	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shuō|LTranslit=shuō|Cxn=Resultative|CxnElt=5:Resultative.Event
+6	完	完	VERB	_	_	5	compound:vv	_	SpaceAfter=No|Translit=wán|LTranslit=wán|CxnElt=5:Resultative.ResultState
 7	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 986
@@ -13603,8 +13603,8 @@
 2	以為	為	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǐwèi|LTranslit=wèi
 3	你	你	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
 4	已	已	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=yǐ|LTranslit=yǐ
-5	發言	發言	VERB	_	_	2	ccomp	_	SpaceAfter=No|Translit=fāyán|LTranslit=fāyán
-6	完畢	完畢	VERB	_	_	5	compound:vv	_	SpaceAfter=No|Translit=wánbì|LTranslit=wánbì
+5	發言	發言	VERB	_	_	2	ccomp	_	SpaceAfter=No|Translit=fāyán|LTranslit=fāyán|Cxn=Resultative|CxnElt=5:Resultative.Event
+6	完畢	完畢	VERB	_	_	5	compound:vv	_	SpaceAfter=No|Translit=wánbì|LTranslit=wánbì|CxnElt=5:Resultative.ResultState
 7	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 988
@@ -13759,8 +13759,8 @@
 11	議事	議事	NOUN	_	_	12	compound	_	SpaceAfter=No|Translit=yìshì|LTranslit=yìshì
 12	規則	規則	NOUN	_	_	14	nsubj	_	SpaceAfter=No|Translit=guīzé|LTranslit=guīzé
 13	》	》	PUNCT	_	_	12	punct	_	SpaceAfter=No|Translit=»|LTranslit=»
-14	訂	訂	VERB	_	_	4	parataxis	_	SpaceAfter=No|Translit=dìng|LTranslit=dìng
-15	明	明	VERB	_	_	14	compound:vv	_	SpaceAfter=No|Translit=míng|LTranslit=míng
+14	訂	訂	VERB	_	_	4	parataxis	_	SpaceAfter=No|Translit=dìng|LTranslit=dìng|Cxn=Resultative|CxnElt=14:Resultative.Event
+15	明	明	VERB	_	_	14	compound:vv	_	SpaceAfter=No|Translit=míng|LTranslit=míng|CxnElt=14:Resultative.ResultState
 16	的	的	PART	_	_	14	mark:rel	_	SpaceAfter=No|Translit=de|LTranslit=de
 17	上	上	DET	_	_	20	det	_	SpaceAfter=No|Translit=shàng|LTranslit=shàng
 18	一	一	NUM	_	_	20	nummod	_	SpaceAfter=No|Translit=yī|LTranslit=yī
@@ -13775,7 +13775,7 @@
 # text = 如何開始下一步選舉主席的會議？
 # translit = rúhékāishǐxiàyībùxuǎnjǔzhǔxídehuìyì?
 1	如何	如何	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=rúhé|LTranslit=rúhé
-2	開始	開始	VERB	_	_	0	root	_	SpaceAfter=No|Translit=kāishǐ|LTranslit=kāishǐ
+2	開始	開始	VERB	_	_	0	root	_	SpaceAfter=No|Translit=kāishǐ|LTranslit=kāishǐ|Cxn=Interrogative-Reduced|CxnElt=2:Interrogative-Reduced.Clause
 3	下	下	DET	_	_	5	det	_	SpaceAfter=No|Translit=xià|LTranslit=xià
 4	一	一	NUM	_	_	5	nummod	_	SpaceAfter=No|Translit=yī|LTranslit=yī
 5	步	步	NOUN	_	NounType=Clf	2	obj	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -13794,8 +13794,8 @@
 4	》	》	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=»|LTranslit=»
 5	已	已	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=yǐ|LTranslit=yǐ
 6	清楚	清楚	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=qīngchu|LTranslit=qīngchu
-7	訂	訂	VERB	_	_	0	root	_	SpaceAfter=No|Translit=dìng|LTranslit=dìng
-8	明	明	VERB	_	_	7	compound:vv	_	SpaceAfter=No|Translit=míng|LTranslit=míng
+7	訂	訂	VERB	_	_	0	root	_	SpaceAfter=No|Translit=dìng|LTranslit=dìng|Cxn=Resultative|CxnElt=7:Resultative.Event
+8	明	明	VERB	_	_	7	compound:vv	_	SpaceAfter=No|Translit=míng|LTranslit=míng|CxnElt=7:Resultative.ResultState
 9	由	由	ADP	_	_	11	mark	_	SpaceAfter=No|Translit=yóu|LTranslit=yóu
 10	議員	議員	NOUN	_	_	11	nsubj	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
 11	宣誓	宣誓	VERB	_	_	16	acl	_	SpaceAfter=No|Translit=xuānshì|LTranslit=xuānshì


### PR DESCRIPTION
Dear maintainers,

Please, ignore my previous PR. This is the good one, I hope...

As part of our work for the paper [UCxn: Typologically Informed Annotation of Constructions Atop Universal Dependencies](https://aclanthology.org/2024.lrec-main.1471.pdf), we annotated some constructions atop UD annotations for many treebanks, including this one.
We thought that these annotations could be added before the new version of the treebank if you agree with the idea. The new annotations will be added in the MISC column, so the core treebank will remain the same. Do you think it will be possible to add them?

Thank you in advance,

Santiago Herrera