### PR TITLE
Parallel data representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Tak-sum WONG, Kim GERDES, Herman LEUNG, and John LEE. "Quantitative Comparative 
 Herman LEUNG, Rafaël POIRET, Tak-sum WONG, Xinying CHEN, Kim GERDES and John LEE. "Developing Universal Dependencies for Mandarin Chinese" Proceedings of the 12th Workshop on Asian Language Resources, pp. 20−29, Osaka, Japan, December 2016.
 
 # Changelog
+
+* 2025-09-12 v2.16
+  * add parallel corpus information to machine-readable metadata
+  * add parallel data support with parallel_id metadata
 * 2024-11-15 v2.15
   * Construction annotations in the [UCxn](https://github.com/LeonieWeissweiler/UCxn) framework added to MISC
 
@@ -86,7 +90,7 @@ Data source: manual
 Data available since: UD v2.1
 License: CC BY-SA 4.0
 Includes text: yes
-Parallel: no
+Parallel: hk
 Genre: spoken
 Lemmas: automatic with corrections
 UPOS: manual native

--- a/zh_hk-ud-test.conllu
+++ b/zh_hk-ud-test.conllu
@@ -1,4 +1,5 @@
 # sent_id = 1
+# parallel_id = hk/1
 # text = 你在找些什麼？
 # translit = nǐzàizhǎoxiēshénme?
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Gloss=2SG|Translit=nǐ|LTranslit=nǐ
@@ -9,6 +10,7 @@
 6	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 2
+# parallel_id = hk/2
 # text = 收拾好哥哥的物品再拿去他的新家。
 # translit = shōushihǎogēgēdewùpǐnzàináqùtādexīnjiā.
 1	收拾	收拾	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shōushi|LTranslit=shōushi|Cxn=Resultative|CxnElt=1:Resultative.Event
@@ -26,6 +28,7 @@
 13	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 3
+# parallel_id = hk/3
 # text = 該取走的都取走了！
 # translit = gāiqǔzǒudedōuqǔzǒule!
 1	該	該	AUX	_	_	2	aux	_	SpaceAfter=No|Translit=gāi|LTranslit=gāi
@@ -39,6 +42,7 @@
 9	！	！	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 4
+# parallel_id = hk/4
 # text = 餘下的都沒用！
 # translit = yúxiàdedōuméiyòng!
 1	餘下	餘下	VERB	_	_	4	nsubj	_	SpaceAfter=No|Translit=yúxià|LTranslit=yúxià
@@ -48,6 +52,7 @@
 5	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 5
+# parallel_id = hk/5
 # text = 也總要有人收拾！
 # translit = yězǒngyàoyǒurénshōushi!
 1	也	也	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=yě|LTranslit=yě
@@ -59,6 +64,7 @@
 7	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 6
+# parallel_id = hk/6
 # text = 豪仔今晚點來吃飯嗎？
 # translit = háozǐjīnwǎndiǎnláichīfànma?
 1	豪仔	豪仔	PROPN	_	_	4	nsubj	_	SpaceAfter=No|Translit=háozǐ|LTranslit=háozǐ
@@ -70,6 +76,7 @@
 7	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 7
+# parallel_id = hk/7
 # text = 他天天在新家與女朋友一起煮菜，都不管我們了。
 # translit = tātiāntiānzàixīnjiāyǔnǚpéngyouyīqǐzhǔcài,dōubùguǎnwǒmenle.
 1	他	他	PRON	_	_	9	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -90,6 +97,7 @@
 16	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 8
+# parallel_id = hk/8
 # text = 這些都沒用了吧？
 # translit = zhèxiēdōuméiyòngleba?
 1	這些	這些	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=zhèxiē|LTranslit=zhèxiē
@@ -100,6 +108,7 @@
 6	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 9
+# parallel_id = hk/9
 # text = 錄影機早也不在了。
 # translit = lùyǐngjīzǎoyěbùzàile.
 1	錄影機	錄影機	NOUN	_	_	5	nsubj	_	SpaceAfter=No|Translit=lùyǐngjī|LTranslit=lùyǐngjī
@@ -111,6 +120,7 @@
 7	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 10
+# parallel_id = hk/10
 # text = 爺爺，我可以去看新一集龍珠嗎？
 # translit = yeye,wǒkěyǐqùkànxīnyījílóngzhūma?
 1	爺爺	爺爺	NOUN	_	_	5	vocative	_	SpaceAfter=No|Translit=yeye|LTranslit=yeye
@@ -127,6 +137,7 @@
 12	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 11
+# parallel_id = hk/11
 # text = 等你媽媽放工回來，跟你對好功課才看吧！
 # translit = děngnǐmāmāfànggōnghuílái,gēnnǐduìhǎogōngkècáikànba!
 1	等	等	VERB	_	_	13	advcl	_	SpaceAfter=No|Translit=děng|LTranslit=děng
@@ -146,6 +157,7 @@
 15	！	！	PUNCT	_	_	13	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 12
+# parallel_id = hk/12
 # text = 爺爺，我做好功課了！
 # translit = yeye,wǒzuòhǎogōngkèle!
 1	爺爺	爺爺	NOUN	_	_	4	vocative	_	SpaceAfter=No|Translit=yeye|LTranslit=yeye
@@ -158,6 +170,7 @@
 8	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 13
+# parallel_id = hk/13
 # text = 默書呢？
 # translit = mòshūne?
 1	默書	默書	VERB	_	_	0	root	_	SpaceAfter=No|Translit=mòshū|LTranslit=mòshū|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
@@ -165,6 +178,7 @@
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 14
+# parallel_id = hk/14
 # text = 沒有啊。
 # translit = méiyǒu'a.
 1	沒有	有	VERB	_	Polarity=Neg	0	root	_	SpaceAfter=No|Translit=méiyǒu|LTranslit=yǒu
@@ -172,12 +186,14 @@
 3	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 15
+# parallel_id = hk/15
 # text = 沒有？
 # translit = méiyǒu?
 1	沒有	有	VERB	_	Polarity=Neg	0	root	_	SpaceAfter=No|Translit=méiyǒu|LTranslit=yǒu|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 16
+# parallel_id = hk/16
 # text = 爺爺，很精彩的！
 # translit = yeye,hěnjīngcǎide!
 1	爺爺	爺爺	NOUN	_	_	4	vocative	_	SpaceAfter=No|Translit=yeye|LTranslit=yeye
@@ -188,6 +204,7 @@
 6	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 17
+# parallel_id = hk/17
 # text = 你跟我一起看吧！
 # translit = nǐgēnwǒyīqǐkànba!
 1	你	你	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -199,6 +216,7 @@
 7	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 18
+# parallel_id = hk/18
 # text = 不看。
 # translit = bùkàn.
 1	不	不	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -206,6 +224,7 @@
 3	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 19
+# parallel_id = hk/19
 # text = 我不愛看這些卡通片。
 # translit = wǒbù'àikànzhèxiēkǎtōngpiàn.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -217,6 +236,7 @@
 7	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 20
+# parallel_id = hk/20
 # text = 爺爺真沒品味！
 # translit = yeyezhēnméipǐnwèi!
 1	爺爺	爺爺	NOUN	_	_	3	nsubj	_	SpaceAfter=No|Translit=yeye|LTranslit=yeye
@@ -226,6 +246,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 21
+# parallel_id = hk/21
 # text = 真是很精彩的！
 # translit = zhēnshìhěnjīngcǎide!
 1	真	真	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=zhēn|LTranslit=zhēn
@@ -236,6 +257,7 @@
 6	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 22
+# parallel_id = hk/22
 # text = 龍珠曾經非常流行。
 # translit = lóngzhūcéngjīngfēichángliúxíng.
 1	龍珠	龍珠	PROPN	_	_	4	nsubj	_	SpaceAfter=No|Translit=lóngzhū|LTranslit=lóngzhū
@@ -245,6 +267,7 @@
 5	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 23
+# parallel_id = hk/23
 # text = 常把龜波氣功掛在口邊。
 # translit = chángbǎguībōqìgōngguàzàikǒubiān.
 1	常	常	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=cháng|LTranslit=cháng
@@ -256,6 +279,7 @@
 7	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 24
+# parallel_id = hk/24
 # text = 三歲到三十歲也喜歡。
 # translit = sānsuìdàosānshísuìyěxǐhuan.
 1	三	三	NUM	_	_	2	nummod	_	SpaceAfter=No|Translit=sān|LTranslit=sān
@@ -268,6 +292,7 @@
 8	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 25
+# parallel_id = hk/25
 # text = 非常誇張。
 # translit = fēicháng誇zhāng.
 1	非常	非常	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=fēicháng|LTranslit=fēicháng
@@ -275,6 +300,7 @@
 3	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 26
+# parallel_id = hk/26
 # text = 走了！
 # translit = zǒule!
 1	走	走	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zǒu|LTranslit=zǒu
@@ -282,6 +308,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 27
+# parallel_id = hk/27
 # text = 回家吧。
 # translit = huíjiāba.
 1	回	回	VERB	_	_	0	root	_	SpaceAfter=No|Translit=huí|LTranslit=huí
@@ -290,6 +317,7 @@
 4	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 28
+# parallel_id = hk/28
 # text = 跟小朋友說再見。
 # translit = gēnxiǎopéngyoushuōzàijiàn.
 1	跟	跟	ADP	_	_	2	case	_	SpaceAfter=No|Translit=gēn|LTranslit=gēn
@@ -299,12 +327,14 @@
 5	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 29
+# parallel_id = hk/29
 # text = 掰掰！
 # translit = bāibāi!
 1	掰掰	掰掰	INTJ	_	_	0	root	_	SpaceAfter=No|Translit=bāibāi|LTranslit=bāibāi
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 30
+# parallel_id = hk/30
 # text = 爺爺，可以走了！
 # translit = yeye,kěyǐzǒule!
 1	爺爺	爺爺	NOUN	_	_	4	vocative	_	SpaceAfter=No|Translit=yeye|LTranslit=yeye
@@ -315,6 +345,7 @@
 6	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 31
+# parallel_id = hk/31
 # text = 趕快吧，爺爺！
 # translit = gǎnkuàiba,yeye!
 1	趕快	趕快	VERB	_	_	0	root	_	SpaceAfter=No|Translit=gǎnkuài|LTranslit=gǎnkuài
@@ -324,6 +355,7 @@
 5	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 32
+# parallel_id = hk/32
 # text = 弄好沒有嗎？
 # translit = nònghǎoméiyǒuma?
 1	弄	弄	VERB	_	_	0	root	_	SpaceAfter=No|Translit=nòng|LTranslit=nòng|Cxn=Interrogative-Polar-Direct,Resultative|CxnElt=1:Interrogative-Polar-Direct.Clause,1:Resultative.Event
@@ -333,6 +365,7 @@
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 33
+# parallel_id = hk/33
 # text = 快好了！
 # translit = kuàihǎole!
 1	快	快	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=kuài|LTranslit=kuài
@@ -341,6 +374,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 34
+# parallel_id = hk/34
 # text = 很好！
 # translit = hěnhǎo!
 1	很	很	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=hěn|LTranslit=hěn
@@ -348,6 +382,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 35
+# parallel_id = hk/35
 # text = 可以了！
 # translit = kěyǐle!
 1	可以	可以	AUX	_	_	0	root	_	SpaceAfter=No|Translit=kěyǐ|LTranslit=kěyǐ
@@ -355,6 +390,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 36
+# parallel_id = hk/36
 # text = 超級撒亞人！
 # translit = chāojísāyàrén!
 1	超級	超級	ADJ	_	_	3	amod	_	SpaceAfter=No|Translit=chāojí|LTranslit=chāojí
@@ -363,6 +399,7 @@
 4	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 37
+# parallel_id = hk/37
 # text = 很強的戰鬥力！
 # translit = hěnqiángdezhàndòulì!
 1	很	很	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=hěn|LTranslit=hěn
@@ -372,6 +409,7 @@
 5	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 38
+# parallel_id = hk/38
 # text = 爺爺，我們快走吧！
 # translit = yeye,wǒmenkuàizǒuba!
 1	爺爺	爺爺	NOUN	_	_	5	vocative	_	SpaceAfter=No|Translit=yeye|LTranslit=yeye
@@ -383,12 +421,14 @@
 7	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 39
+# parallel_id = hk/39
 # text = 多多！
 # translit = duōduō!
 1	多多	多多	PROPN	_	_	0	root	_	SpaceAfter=No|Translit=duōduō|LTranslit=duōduō
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 40
+# parallel_id = hk/40
 # text = 你只記著益力多！
 # translit = nǐzhǐjìzheyìlìduō!
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -399,6 +439,7 @@
 6	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 41
+# parallel_id = hk/41
 # text = 不要弄！
 # translit = bùyàonòng!
 1	不要	要	AUX	_	Polarity=Neg	2	aux	_	SpaceAfter=No|Translit=bùyào|LTranslit=yào
@@ -406,6 +447,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 42
+# parallel_id = hk/42
 # text = 小心別跌出來！
 # translit = xiǎoxīnbiédiēchūlái!
 1	小心	小心	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=xiǎoxīn|LTranslit=xiǎoxīn
@@ -415,6 +457,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 43
+# parallel_id = hk/43
 # text = 斤半！
 # translit = jīnbàn!
 1	斤	斤	NOUN	_	NounType=Clf	0	root	_	SpaceAfter=No|Translit=jīn|LTranslit=jīn
@@ -422,12 +465,14 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 44
+# parallel_id = hk/44
 # text = 知道。
 # translit = zhīdào.
 1	知道	知道	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhīdào|LTranslit=zhīdào
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 45
+# parallel_id = hk/45
 # text = 該走了！
 # translit = gāizǒule!
 1	該	該	AUX	_	_	2	aux	_	SpaceAfter=No|Translit=gāi|LTranslit=gāi
@@ -436,6 +481,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 46
+# parallel_id = hk/46
 # text = 六十六塊四
 # translit = liùshíliùkuàisì
 1	六十六	六十六	NUM	_	_	2	nummod	_	SpaceAfter=No|Translit=liùshíliù|LTranslit=liùshíliù
@@ -443,12 +489,14 @@
 3	四	四	NUM	_	_	2	conj	_	SpaceAfter=No|Translit=sì|LTranslit=sì
 
 # sent_id = 47
+# parallel_id = hk/47
 # text = 多少？
 # translit = duōshǎo?
 1	多少	多少	PRON	_	_	0	root	_	SpaceAfter=No|Translit=duōshǎo|LTranslit=duōshǎo|Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 48
+# parallel_id = hk/48
 # text = 六十六塊四
 # translit = liùshíliùkuàisì
 1	六十六	六十六	NUM	_	_	2	nummod	_	SpaceAfter=No|Translit=liùshíliù|LTranslit=liùshíliù
@@ -456,6 +504,7 @@
 3	四	四	NUM	_	_	2	conj	_	SpaceAfter=No|Translit=sì|LTranslit=sì
 
 # sent_id = 49
+# parallel_id = hk/49
 # text = 收你一百。
 # translit = shōunǐyībǎi.
 1	收	收	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shōu|LTranslit=shōu
@@ -464,6 +513,7 @@
 4	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 50
+# parallel_id = hk/50
 # text = 找你三十三塊六
 # translit = zhǎonǐsānshísānkuàiliù
 1	找	找	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhǎo|LTranslit=zhǎo
@@ -473,6 +523,7 @@
 5	六	六	NUM	_	_	4	conj	_	SpaceAfter=No|Translit=liù|LTranslit=liù
 
 # sent_id = 51
+# parallel_id = hk/51
 # text = 姐姐，這些錢給我便行了！
 # translit = jiejie,zhèxiēqiángěiwǒbiànxíngle!
 1	姐姐	姐姐	NOUN	_	_	8	vocative	_	SpaceAfter=No|Translit=jiejie|LTranslit=jiejie
@@ -487,6 +538,7 @@
 10	！	！	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 52
+# parallel_id = hk/52
 # text = 這些是爺爺的！
 # translit = zhèxiēshìyeyede!
 1	這些	這些	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=zhèxiē|LTranslit=zhèxiē
@@ -496,6 +548,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 53
+# parallel_id = hk/53
 # text = 這些呢？
 # translit = zhèxiēne?
 1	這些	這些	PRON	_	_	0	root	_	SpaceAfter=No|Translit=zhèxiē|LTranslit=zhèxiē|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
@@ -503,6 +556,7 @@
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 54
+# parallel_id = hk/54
 # text = 是我的！
 # translit = shìwǒde!
 1	是	是	AUX	_	_	2	cop	_	SpaceAfter=No|Translit=shì|LTranslit=shì
@@ -511,6 +565,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 55
+# parallel_id = hk/55
 # text = 他常常說，沒有龍珠閃卡就沒有朋友。
 # translit = tāchángchángshuō,méiyǒulóngzhūshǎnkǎjiùméiyǒupéngyou.
 1	他	他	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -526,6 +581,7 @@
 11	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 56
+# parallel_id = hk/56
 # text = 不知這是什麼邏輯。
 # translit = bùzhīzhèshìshénmeluóji.
 1	不	不	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -537,6 +593,7 @@
 7	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 57
+# parallel_id = hk/57
 # text = 只是他沒有什麼運氣。
 # translit = zhǐshìtāméiyǒushénmeyùnqì.
 1	只是	只是	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=zhǐshì|LTranslit=zhǐshì
@@ -547,12 +604,14 @@
 6	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 58
+# parallel_id = hk/58
 # text = 媽媽！
 # translit = māmā!
 1	媽媽	媽媽	NOUN	_	_	0	root	_	SpaceAfter=No|Translit=māmā|LTranslit=māmā
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 59
+# parallel_id = hk/59
 # text = 有什麼事？
 # translit = yǒushénmeshì?
 1	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
@@ -561,6 +620,7 @@
 4	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 60
+# parallel_id = hk/60
 # text = 我默書一百分。
 # translit = wǒmòshūyībǎifēn.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -570,6 +630,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 61
+# parallel_id = hk/61
 # text = 讓我看看。
 # translit = ràngwǒkànkàn.
 1	讓	讓	VERB	_	_	0	root	_	SpaceAfter=No|Translit=ràng|LTranslit=ràng
@@ -578,6 +639,7 @@
 4	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 62
+# parallel_id = hk/62
 # text = 真聰明！
 # translit = zhēncōngmíng!
 1	真	真	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zhēn|LTranslit=zhēn
@@ -585,6 +647,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 63
+# parallel_id = hk/63
 # text = 媽媽明天煮雞翼獎勵你。
 # translit = māmāmíngtiānzhǔjīyìjiǎnglìnǐ.
 1	媽媽	媽媽	NOUN	_	_	3	nsubj	_	SpaceAfter=No|Translit=māmā|LTranslit=māmā
@@ -596,6 +659,7 @@
 7	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 64
+# parallel_id = hk/64
 # text = 我不要雞翼，我要零用錢。
 # translit = wǒbùyàojīyì,wǒyàolíngyòngqián.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -609,6 +673,7 @@
 9	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 65
+# parallel_id = hk/65
 # text = 那我去拿給你。
 # translit = nàwǒqùnágěinǐ.
 1	那	那	ADV	_	_	3	discourse	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -620,6 +685,7 @@
 7	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 66
+# parallel_id = hk/66
 # text = 要乖別搗蛋啊！
 # translit = yàoguāibiédǎodàn'a!
 1	要	要	AUX	_	_	2	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
@@ -630,6 +696,7 @@
 6	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 67
+# parallel_id = hk/67
 # text = 你洗手了嗎？
 # translit = nǐxǐshǒulema?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -640,6 +707,7 @@
 6	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 68
+# parallel_id = hk/68
 # text = 洗乾淨了！
 # translit = xǐ乾jìngle!
 1	洗	洗	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xǐ|LTranslit=xǐ|Cxn=Resultative|CxnElt=1:Resultative.Event
@@ -648,6 +716,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 69
+# parallel_id = hk/69
 # text = 算你乖！
 # translit = suànnǐguāi!
 1	算	算	VERB	_	_	0	root	_	SpaceAfter=No|Translit=suàn|LTranslit=suàn
@@ -656,6 +725,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 70
+# parallel_id = hk/70
 # text = 要繼續乖乖讀書。
 # translit = yàojìxùguāiguāidúshū.
 1	要	要	AUX	_	_	2	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
@@ -665,12 +735,14 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 71
+# parallel_id = hk/71
 # text = 知道。
 # translit = zhīdào.
 1	知道	知道	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhīdào|LTranslit=zhīdào
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 72
+# parallel_id = hk/72
 # text = 快去做功課吧。
 # translit = kuàiqùzuògōngkèba.
 1	快	快	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=kuài|LTranslit=kuài
@@ -681,6 +753,7 @@
 6	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 73
+# parallel_id = hk/73
 # text = 我要十個一元！
 # translit = wǒyàoshígèyīyuán!
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -692,6 +765,7 @@
 7	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 74
+# parallel_id = hk/74
 # text = 十個一元。
 # translit = shígèyīyuán.
 1	十	十	NUM	_	_	4	nummod	_	SpaceAfter=No|Translit=shí|LTranslit=shí
@@ -701,12 +775,14 @@
 5	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 75
+# parallel_id = hk/75
 # text = 謝謝！
 # translit = xièxiè!
 1	謝謝	謝謝	INTJ	_	_	0	root	_	SpaceAfter=No|Translit=xièxiè|LTranslit=xièxiè
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 76
+# parallel_id = hk/76
 # text = 換好吧？
 # translit = huànhǎoba?
 1	換	換	VERB	_	_	0	root	_	SpaceAfter=No|Translit=huàn|LTranslit=huàn|Cxn=Interrogative-Reduced,Resultative|CxnElt=1:Interrogative-Reduced.Clause,1:Resultative.Event
@@ -715,6 +791,7 @@
 4	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 77
+# parallel_id = hk/77
 # text = 真好運！
 # translit = zhēnhǎoyùn!
 1	真	真	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zhēn|LTranslit=zhēn
@@ -722,6 +799,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 78
+# parallel_id = hk/78
 # text = 這不就是你很喜歡的悟空嗎？
 # translit = zhèbùjiùshìnǐhěnxǐhuandewùkōngma?
 1	這	這	PRON	_	_	9	nsubj	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -737,6 +815,7 @@
 11	？	？	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 79
+# parallel_id = hk/79
 # text = 又不是閃卡！
 # translit = yòubùshìshǎnkǎ!
 1	又	又	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=yòu|LTranslit=yòu
@@ -746,6 +825,7 @@
 5	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 80
+# parallel_id = hk/80
 # text = 走吧，該回家了！
 # translit = zǒuba,gāihuíjiāle!
 1	走	走	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zǒu|LTranslit=zǒu
@@ -758,6 +838,7 @@
 8	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 81
+# parallel_id = hk/81
 # text = 玩夠了！
 # translit = wángòule!
 1	玩	玩	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wán|LTranslit=wán|Cxn=Resultative|CxnElt=1:Resultative.Event
@@ -766,6 +847,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 82
+# parallel_id = hk/82
 # text = 爺爺，快多給我兩元！
 # translit = yeye,kuàiduōgěiwǒliǎngyuán!
 1	爺爺	爺爺	NOUN	_	_	5	vocative	_	SpaceAfter=No|Translit=yeye|LTranslit=yeye
@@ -779,6 +861,7 @@
 9	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 83
+# parallel_id = hk/83
 # text = 閃卡快出現了！
 # translit = shǎnkǎkuàichūxiànle!
 1	閃卡	閃卡	NOUN	_	_	3	nsubj	_	SpaceAfter=No|Translit=shǎnkǎ|LTranslit=shǎnkǎ
@@ -788,6 +871,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 84
+# parallel_id = hk/84
 # text = 爺爺，你給我啦！
 # translit = yeye,nǐgěiwǒla!
 1	爺爺	爺爺	NOUN	_	_	4	vocative	_	SpaceAfter=No|Translit=yeye|LTranslit=yeye
@@ -799,6 +883,7 @@
 7	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 85
+# parallel_id = hk/85
 # text = 你給我吧！
 # translit = nǐgěiwǒba!
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -808,12 +893,14 @@
 5	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 86
+# parallel_id = hk/86
 # text = 哎吔！
 # translit = 'āi吔!
 1	哎吔	哎吔	INTJ	_	_	0	root	_	SpaceAfter=No|Translit='āi吔|LTranslit='āi吔
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 87
+# parallel_id = hk/87
 # text = 你給我扭兩張吧！
 # translit = nǐgěiwǒniǔliǎngzhāngba!
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -826,12 +913,14 @@
 8	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 88
+# parallel_id = hk/88
 # text = 嘩！
 # translit = huā!
 1	嘩	嘩	INTJ	_	_	0	root	_	SpaceAfter=No|Translit=huā|LTranslit=huā
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 89
+# parallel_id = hk/89
 # text = 是閃的！
 # translit = shìshǎnde!
 1	是	是	AUX	_	_	2	cop	_	SpaceAfter=No|Translit=shì|LTranslit=shì
@@ -840,6 +929,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 90
+# parallel_id = hk/90
 # text = 交換看！
 # translit = jiāohuànkàn!
 1	交換	交換	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jiāohuàn|LTranslit=jiāohuàn
@@ -847,6 +937,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 91
+# parallel_id = hk/91
 # text = 拿來看看吧！
 # translit = náláikànkànba!
 1	拿	拿	VERB	_	_	0	root	_	SpaceAfter=No|Translit=ná|LTranslit=ná
@@ -856,6 +947,7 @@
 5	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 92
+# parallel_id = hk/92
 # text = 都是爺爺的錯。
 # translit = dōushìyeyedecuò.
 1	都	都	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=dōu|LTranslit=dōu
@@ -866,6 +958,7 @@
 6	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 93
+# parallel_id = hk/93
 # text = 那閃卡本應屬於我的。
 # translit = nàshǎnkǎběnyīngshǔyúwǒde.
 1	那	那	DET	_	_	2	det	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -878,6 +971,7 @@
 8	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 94
+# parallel_id = hk/94
 # text = 走吧！
 # translit = zǒuba!
 1	走	走	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zǒu|LTranslit=zǒu
@@ -885,6 +979,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 95
+# parallel_id = hk/95
 # text = 我不理你了！
 # translit = wǒbùlǐnǐle!
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -895,6 +990,7 @@
 6	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 96
+# parallel_id = hk/96
 # text = 真的一張閃卡也沒有。
 # translit = zhēndeyīzhāngshǎnkǎyěméiyǒu.
 1	真的	真的	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=zhēnde|LTranslit=zhēnde
@@ -906,6 +1002,7 @@
 7	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 97
+# parallel_id = hk/97
 # text = 過了這麼多年。
 # translit = guòlezhèmeduōnián.
 1	過	過	VERB	_	_	0	root	_	SpaceAfter=No|Translit=guò|LTranslit=guò
@@ -916,6 +1013,7 @@
 6	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 98
+# parallel_id = hk/98
 # text = 都不知去哪兒了。
 # translit = dōubùzhīqùnǎrle.
 1	都	都	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=dōu|LTranslit=dōu
@@ -927,6 +1025,7 @@
 7	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 99
+# parallel_id = hk/99
 # text = 給哥哥看看才行。
 # translit = gěigēgēkànkàncáixíng.
 1	給	給	VERB	_	_	5	advcl	_	SpaceAfter=No|Translit=gěi|LTranslit=gěi
@@ -937,6 +1036,7 @@
 6	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 100
+# parallel_id = hk/100
 # text = 你順便再問問豪仔晚上會否回來吃飯。
 # translit = nǐshùnbiànzàiwènwènháozǐwǎnshànghuìfǒuhuíláichīfàn.
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -952,6 +1052,7 @@
 11	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 101
+# parallel_id = hk/101
 # text = 有餸。
 # translit = yǒu餸.
 1	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
@@ -959,12 +1060,14 @@
 3	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 102
+# parallel_id = hk/102
 # text = 哦。
 # translit = 'ó.
 1	哦	哦	INTJ	_	_	0	root	_	SpaceAfter=No|Translit='ó|LTranslit='ó
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 103
+# parallel_id = hk/103
 # text = 這些錄影帶很麻煩。
 # translit = zhèxiēlùyǐngdàihěnmáfán.
 1	這些	這些	DET	_	_	2	det	_	SpaceAfter=No|Translit=zhèxiē|LTranslit=zhèxiē
@@ -974,6 +1077,7 @@
 5	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 104
+# parallel_id = hk/104
 # text = 用耐了便壞。
 # translit = yòngnàilebiànhuài.
 1	用	用	VERB	_	_	5	advcl	_	SpaceAfter=No|Translit=yòng|LTranslit=yòng|Cxn=Resultative|CxnElt=1:Resultative.Event
@@ -984,6 +1088,7 @@
 6	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 105
+# parallel_id = hk/105
 # text = 都是無線電視的錯！
 # translit = dōushìwúxiàndiànshìdecuò!
 1	都	都	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=dōu|LTranslit=dōu
@@ -994,6 +1099,7 @@
 6	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 106
+# parallel_id = hk/106
 # text = 深夜才播卡通片，令小朋友們都捱夜追看。
 # translit = shēnyècáibōkǎtōngpiàn,lìngxiǎopéngyoumendōu捱yèzhuīkàn.
 1	深夜	深夜	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No|Translit=shēnyè|LTranslit=shēnyè
@@ -1010,12 +1116,14 @@
 12	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 107
+# parallel_id = hk/107
 # text = 唉！
 # translit = 唉!
 1	唉	唉	INTJ	_	_	0	root	_	SpaceAfter=No|Translit=唉|LTranslit=唉
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 108
+# parallel_id = hk/108
 # text = 差不多半夜一時才去睡。
 # translit = chàbùduōbànyèyīshícáiqùshuì.
 1	差不多	差不多	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=chàbùduō|LTranslit=chàbùduō
@@ -1028,6 +1136,7 @@
 8	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 109
+# parallel_id = hk/109
 # text = 我和哥哥小時候也愛晚上偷偷出廳看金田一。
 # translit = wǒhégēgēxiǎoshíhouyě'àiwǎnshàngtōutōuchūtīngkànjīntiányī.
 1	我	我	PRON	_	_	6	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -1045,6 +1154,7 @@
 13	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 110
+# parallel_id = hk/110
 # text = 半夜不能開燈看真的很恐怖！
 # translit = bànyèbùnéngkāidēngkànzhēndehěnkǒngbù!
 1	半夜	半夜	NOUN	_	_	6	obl:tmod	_	SpaceAfter=No|Translit=bànyè|LTranslit=bànyè
@@ -1060,6 +1170,7 @@
 11	！	！	PUNCT	_	_	10	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 111
+# parallel_id = hk/111
 # text = 但又怕給你們發現。
 # translit = dànyòupàgěinǐmenfāxiàn.
 1	但	但	CCONJ	_	_	2	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -1071,6 +1182,7 @@
 7	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 112
+# parallel_id = hk/112
 # text = 兩兄妹都這樣。
 # translit = liǎngxiōngmèidōuzhèyàng.
 1	兩兄妹	兩兄妹	NOUN	_	_	3	nsubj	_	SpaceAfter=No|Translit=liǎngxiōngmèi|LTranslit=liǎngxiōngmèi
@@ -1079,6 +1191,7 @@
 4	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 113
+# parallel_id = hk/113
 # text = 爺爺，你讓我多看十分鐘吧！
 # translit = yeye,nǐràngwǒduōkànshífēnzhōngba!
 1	爺爺	爺爺	NOUN	_	_	4	vocative	_	SpaceAfter=No|Translit=yeye|LTranslit=yeye
@@ -1094,6 +1207,7 @@
 11	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 114
+# parallel_id = hk/114
 # text = 快播完了！
 # translit = kuàibōwánle!
 1	快	快	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=kuài|LTranslit=kuài
@@ -1103,6 +1217,7 @@
 5	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 115
+# parallel_id = hk/115
 # text = 不行！
 # translit = bùxíng!
 1	不	不	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -1110,6 +1225,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 116
+# parallel_id = hk/116
 # text = 快去睡！
 # translit = kuàiqùshuì!
 1	快	快	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=kuài|LTranslit=kuài
@@ -1118,6 +1234,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 117
+# parallel_id = hk/117
 # text = 明天再給你看錄影帶！
 # translit = míngtiānzàigěinǐkànlùyǐngdài!
 1	明天	明天	NOUN	_	_	5	obl:tmod	_	SpaceAfter=No|Translit=míngtiān|LTranslit=míngtiān
@@ -1129,6 +1246,7 @@
 7	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 118
+# parallel_id = hk/118
 # text = 你讓我看啦！
 # translit = nǐràngwǒkànla!
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -1139,6 +1257,7 @@
 6	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 119
+# parallel_id = hk/119
 # text = 不行！
 # translit = bùxíng!
 1	不	不	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -1146,6 +1265,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 120
+# parallel_id = hk/120
 # text = 走啦！
 # translit = zǒula!
 1	走	走	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zǒu|LTranslit=zǒu
@@ -1153,6 +1273,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 121
+# parallel_id = hk/121
 # text = 爺爺，你給我看吧！
 # translit = yeye,nǐgěiwǒkànba!
 1	爺爺	爺爺	NOUN	_	_	6	vocative	_	SpaceAfter=No|Translit=yeye|LTranslit=yeye
@@ -1165,6 +1286,7 @@
 8	！	！	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 122
+# parallel_id = hk/122
 # text = 要去睡了！
 # translit = yàoqùshuìle!
 1	要	要	AUX	_	_	2	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
@@ -1174,6 +1296,7 @@
 5	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 123
+# parallel_id = hk/123
 # text = 你讓我繼續看啦！
 # translit = nǐràngwǒjìxùkànla!
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -1185,6 +1308,7 @@
 7	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 124
+# parallel_id = hk/124
 # text = 走啦！
 # translit = zǒula!
 1	走	走	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zǒu|LTranslit=zǒu
@@ -1192,6 +1316,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 125
+# parallel_id = hk/125
 # text = 走啦！
 # translit = zǒula!
 1	走	走	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zǒu|LTranslit=zǒu
@@ -1199,6 +1324,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 126
+# parallel_id = hk/126
 # text = 快走！
 # translit = kuàizǒu!
 1	快	快	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=kuài|LTranslit=kuài
@@ -1206,6 +1332,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 127
+# parallel_id = hk/127
 # text = 快去睡！
 # translit = kuàiqùshuì!
 1	快	快	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=kuài|LTranslit=kuài
@@ -1214,6 +1341,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 128
+# parallel_id = hk/128
 # text = 你們常常都忘了幫我錄。
 # translit = nǐmenchángchángdōuwànglebāngwǒlù.
 1	你們	你們	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐmen|LTranslit=nǐmen
@@ -1227,6 +1355,7 @@
 9	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 129
+# parallel_id = hk/129
 # text = 那天開始，我們懂得玩這個遊戲。
 # translit = nàtiānkāishǐ,wǒmendǒngdewánzhègèyóuxì.
 1	那	那	DET	_	_	2	det	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -1242,6 +1371,7 @@
 11	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 130
+# parallel_id = hk/130
 # text = 一般每二十多張白卡便出一張閃卡。
 # translit = yībānměi'èrshíduōzhāngbáikǎbiànchūyīzhāngshǎnkǎ.
 1	一般	一般	NOUN	_	_	7	obl:tmod	_	SpaceAfter=No|Translit=yībān|LTranslit=yībān
@@ -1257,6 +1387,7 @@
 11	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 131
+# parallel_id = hk/131
 # text = 我們開始懂得跟隊。
 # translit = wǒmenkāishǐdǒngdegēnduì.
 1	我們	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
@@ -1266,6 +1397,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 132
+# parallel_id = hk/132
 # text = 見到別人有十個一元左右，就排在他後面。
 # translit = jiàndàobiérényǒushígèyīyuánzuǒyòu,jiùpáizàitāhòumiàn.
 1	見	見	VERB	_	_	12	advcl	_	SpaceAfter=No|Translit=jiàn|LTranslit=jiàn|Cxn=Resultative|CxnElt=1:Resultative.Event
@@ -1286,6 +1418,7 @@
 16	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 133
+# parallel_id = hk/133
 # text = 等他扭光十元也不中閃卡時，我們便行動。
 # translit = děngtāniǔguāngshíyuányěbùzhōngshǎnkǎshí,wǒmenbiànxíngdòng.
 1	等	等	VERB	_	_	15	advcl	_	SpaceAfter=No|Translit=děng|LTranslit=děng
@@ -1306,6 +1439,7 @@
 16	。	。	PUNCT	_	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 134
+# parallel_id = hk/134
 # text = 扭卡一定要帶電筒。
 # translit = niǔkǎyīdìngyàodàidiàntǒng.
 1	扭	扭	VERB	_	_	5	advcl	_	SpaceAfter=No|Translit=niǔ|LTranslit=niǔ
@@ -1317,6 +1451,7 @@
 7	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 135
+# parallel_id = hk/135
 # text = 唉！跟做賊差不多。
 # translit = 唉!gēnzuòzéichàbùduō.
 1	唉	唉	INTJ	_	_	6	discourse	_	SpaceAfter=No|Translit=唉|LTranslit=唉
@@ -1328,6 +1463,7 @@
 7	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 136
+# parallel_id = hk/136
 # text = 喂，小鬼！
 # translit = wèi,xiǎoguǐ!
 1	喂	喂	INTJ	_	_	3	discourse	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
@@ -1336,6 +1472,7 @@
 4	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 137
+# parallel_id = hk/137
 # text = 不要弄壞我的機。
 # translit = bùyàonònghuàiwǒdejī.
 1	不要	要	AUX	_	Polarity=Neg	2	aux	_	SpaceAfter=No|Translit=bùyào|LTranslit=yào
@@ -1347,12 +1484,14 @@
 7	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 138
+# parallel_id = hk/138
 # text = 對不起！
 # translit = duìbùqǐ!
 1	對不起	對不起	VERB	_	_	0	root	_	SpaceAfter=No|Translit=duìbùqǐ|LTranslit=duìbùqǐ
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 139
+# parallel_id = hk/139
 # text = 別跑！
 # translit = biépǎo!
 1	別	別	AUX	_	_	2	aux	_	SpaceAfter=No|Translit=bié|LTranslit=bié
@@ -1360,6 +1499,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 140
+# parallel_id = hk/140
 # text = 快點！
 # translit = kuàidiǎn!
 1	快	快	ADV	_	_	0	root	_	SpaceAfter=No|Translit=kuài|LTranslit=kuài
@@ -1367,6 +1507,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 141
+# parallel_id = hk/141
 # text = 沒力氣啦！
 # translit = méilìqìla!
 1	沒	沒	VERB	_	_	0	root	_	SpaceAfter=No|Translit=méi|LTranslit=méi
@@ -1375,6 +1516,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 142
+# parallel_id = hk/142
 # text = 快跑呀，爺爺！
 # translit = kuàipǎoya,yeye!
 1	快	快	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=kuài|LTranslit=kuài
@@ -1385,6 +1527,7 @@
 6	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 143
+# parallel_id = hk/143
 # text = 快要被人抓到了！
 # translit = kuàiyàobèirénzhuādàole!
 1	快	快	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=kuài|LTranslit=kuài
@@ -1397,12 +1540,14 @@
 8	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 144
+# parallel_id = hk/144
 # text = 豪仔！
 # translit = háozǐ!
 1	豪仔	豪仔	PROPN	_	_	0	root	_	SpaceAfter=No|Translit=háozǐ|LTranslit=háozǐ
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 145
+# parallel_id = hk/145
 # text = 你在哪？
 # translit = nǐzàinǎ?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -1411,12 +1556,14 @@
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 146
+# parallel_id = hk/146
 # text = 豪仔！
 # translit = háozǐ!
 1	豪仔	豪仔	PROPN	_	_	0	root	_	SpaceAfter=No|Translit=háozǐ|LTranslit=háozǐ
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 147
+# parallel_id = hk/147
 # text = 你在哪？
 # translit = nǐzàinǎ?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -1425,6 +1572,7 @@
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 148
+# parallel_id = hk/148
 # text = 很累。
 # translit = hěnlèi.
 1	很	很	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=hěn|LTranslit=hěn
@@ -1432,6 +1580,7 @@
 3	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 149
+# parallel_id = hk/149
 # text = 爺爺，你看！
 # translit = yeye,nǐkàn!
 1	爺爺	爺爺	NOUN	_	_	4	vocative	_	SpaceAfter=No|Translit=yeye|LTranslit=yeye
@@ -1441,6 +1590,7 @@
 5	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 150
+# parallel_id = hk/150
 # text = 原來閃卡都在哥哥新家。
 # translit = yuánláishǎnkǎdōuzàigēgēxīnjiā.
 1	原來	原來	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=yuánlái|LTranslit=yuánlái
@@ -1453,6 +1603,7 @@
 8	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 151
+# parallel_id = hk/151
 # text = 你怎麼知道？
 # translit = nǐzěnmezhīdào?
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -1461,6 +1612,7 @@
 4	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 152
+# parallel_id = hk/152
 # text = 他剛告訴我的。
 # translit = tāgānggàosuwǒde.
 1	他	他	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -1471,6 +1623,7 @@
 6	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 153
+# parallel_id = hk/153
 # text = 是嘛？
 # translit = shìma?
 1	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
@@ -1478,6 +1631,7 @@
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 154
+# parallel_id = hk/154
 # text = 喂，從前你常帶哥哥四處走。
 # translit = wèi,cóngqiánnǐchángdàigēgēsìchùzǒu.
 1	喂	喂	INTJ	_	_	6	discourse	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
@@ -1492,6 +1646,7 @@
 10	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 155
+# parallel_id = hk/155
 # text = 那時我在去了哪裡？
 # translit = nàshíwǒzàiqùlenǎli?
 1	那時	那時	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=nàshí|LTranslit=nàshí
@@ -1503,12 +1658,14 @@
 7	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 156
+# parallel_id = hk/156
 # text = 你？
 # translit = nǐ?
 1	你	你	PRON	_	_	0	root	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 157
+# parallel_id = hk/157
 # text = 你還沒出世！
 # translit = nǐháiméichūshì!
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -1518,6 +1675,7 @@
 5	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 158
+# parallel_id = hk/158
 # text = 怎可能？
 # translit = zěnkěnéng?
 1	怎	怎	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zěn|LTranslit=zěn|CxnElt=2:Interrogative-WHInfo-Direct.WHWord
@@ -1525,6 +1683,7 @@
 3	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 159
+# parallel_id = hk/159
 # text = 我才小他幾歲。
 # translit = wǒcáixiǎotājǐsuì.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -1536,6 +1695,7 @@
 7	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 160
+# parallel_id = hk/160
 # text = 我忘了！
 # translit = wǒwàngle!
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -1544,6 +1704,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 161
+# parallel_id = hk/161
 # text = 你偏心！
 # translit = nǐpiānxīn!
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -1551,6 +1712,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 162
+# parallel_id = hk/162
 # text = 我來，我來！
 # translit = wǒlái,wǒlái!
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -1561,6 +1723,7 @@
 6	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 163
+# parallel_id = hk/163
 # text = 你先坐下！
 # translit = nǐxiānzuòxià!
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -1570,6 +1733,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 164
+# parallel_id = hk/164
 # text = 你心虛啊？
 # translit = nǐxīnxū'a?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -1578,6 +1742,7 @@
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 165
+# parallel_id = hk/165
 # text = 你趕快收拾吧！
 # translit = nǐgǎnkuàishōushiba!
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -1587,6 +1752,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 166
+# parallel_id = hk/166
 # text = 剛剛才說要拿去哥哥那邊！
 # translit = gānggāngcáishuōyàonáqùgēgēnàbiān!
 1	剛剛	剛剛	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=gānggāng|LTranslit=gānggāng
@@ -1600,6 +1766,7 @@
 9	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 167
+# parallel_id = hk/167
 # text = 她女朋友也在。
 # translit = tānǚpéngyouyězài.
 1	她	她	PRON	_	_	2	nmod	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -1609,6 +1776,7 @@
 5	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 168
+# parallel_id = hk/168
 # text = 我才免得做電燈泡。
 # translit = wǒcáimiǎndezuòdiàndēngpào.
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -1619,6 +1787,7 @@
 6	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 169
+# parallel_id = hk/169
 # text = 你知道嗎？
 # translit = nǐzhīdàoma?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -1627,6 +1796,7 @@
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 170
+# parallel_id = hk/170
 # text = 陳奕迅跟楊千嬅剛出道時，他們是一對的。
 # translit = chén奕xùngēnyángqiān嬅gāngchūdàoshí,tāmenshìyīduìde.
 1	陳奕迅	陳奕迅	PROPN	_	_	5	nsubj	_	SpaceAfter=No|Translit=chén奕xùn|LTranslit=chén奕xùn
@@ -1644,6 +1814,7 @@
 13	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 171
+# parallel_id = hk/171
 # text = 我又不認識他們。
 # translit = wǒyòubùrènshitāmen.
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -1654,6 +1825,7 @@
 6	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 172
+# parallel_id = hk/172
 # text = 對了，那時候你們一個喜歡陳奕迅，一個喜歡黎明。
 # translit = duìle,nàshíhounǐmenyīgèxǐhuanchén奕xùn,yīgèxǐhuanlímíng.
 1	對	對	VERB	_	_	0	root	_	SpaceAfter=No|Translit=duì|LTranslit=duì
@@ -1674,6 +1846,7 @@
 16	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 173
+# parallel_id = hk/173
 # text = 誰喜歡哪個我都忘了。
 # translit = shuíxǐhuannǎgèwǒdōuwàngle.
 1	誰	誰	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=shuí|LTranslit=shuí
@@ -1686,6 +1859,7 @@
 8	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 174
+# parallel_id = hk/174
 # text = 哪有人喜歡黎明？
 # translit = nǎyǒurénxǐhuanlímíng?
 1	哪	哪	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=nǎ|LTranslit=nǎ|CxnElt=2:Interrogative-WHInfo-Direct.WHWord
@@ -1696,6 +1870,7 @@
 6	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 175
+# parallel_id = hk/175
 # text = 一定是哥哥胡說！
 # translit = yīdìngshìgēgēhúshuō!
 1	一定	一定	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=yīdìng|LTranslit=yīdìng
@@ -1705,6 +1880,7 @@
 5	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 176
+# parallel_id = hk/176
 # text = 我從沒喜歡什麼明星！
 # translit = wǒcóngméixǐhuanshénmemíngxīng!
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -1715,6 +1891,7 @@
 6	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 177
+# parallel_id = hk/177
 # text = 你可以……做我的……筆友嗎？
 # translit = nǐkěyǐ……zuòwǒde……bǐyouma?
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -1729,6 +1906,7 @@
 10	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 178
+# parallel_id = hk/178
 # text = 你也知我不愛上課！
 # translit = nǐyězhīwǒbù'àishàngkè!
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -1741,6 +1919,7 @@
 8	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 179
+# parallel_id = hk/179
 # text = 什麼眾數、平均數、中位數？
 # translit = shénmezhòngshù,píngjūnshù,zhōngwèishù?
 1	什麼	什麼	DET	_	_	2	det	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|CxnElt=2:Interrogative-WHInfo-Direct.WHWord
@@ -1752,6 +1931,7 @@
 7	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 180
+# parallel_id = hk/180
 # text = 怎麼分辨？
 # translit = zěnmefēnbiàn?
 1	怎麼	怎麼	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zěnme|LTranslit=zěnme|CxnElt=2:Interrogative-WHInfo-Direct.WHWord
@@ -1759,6 +1939,7 @@
 3	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 181
+# parallel_id = hk/181
 # text = 我不懂。
 # translit = wǒbùdǒng.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -1767,6 +1948,7 @@
 4	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 182
+# parallel_id = hk/182
 # text = 最高頻率那組嗎？
 # translit = zuìgāopínlǜnàzǔma?
 1	最	最	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zuì|LTranslit=zuì
@@ -1778,12 +1960,14 @@
 7	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 183
+# parallel_id = hk/183
 # text = 哦。
 # translit = 'ó.
 1	哦	哦	INTJ	_	_	0	root	_	SpaceAfter=No|Translit='ó|LTranslit='ó
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 184
+# parallel_id = hk/184
 # text = 平均數呢？
 # translit = píngjūnshùne?
 1	平均數	平均數	NOUN	_	_	0	root	_	SpaceAfter=No|Translit=píngjūnshù|LTranslit=píngjūnshù|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
@@ -1791,6 +1975,7 @@
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 185
+# parallel_id = hk/185
 # text = 你就刻薄！
 # translit = nǐjiùkèbáo!
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -1799,6 +1984,7 @@
 4	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 186
+# parallel_id = hk/186
 # text = 啊，原來這樣！
 # translit = 'a,yuánláizhèyàng!
 1	啊	啊	INTJ	_	_	4	discourse	_	SpaceAfter=No|Translit='a|LTranslit='a
@@ -1808,6 +1994,7 @@
 5	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 187
+# parallel_id = hk/187
 # text = 差不多了。
 # translit = chàbùduōle.
 1	差不多	差不多	ADV	_	_	0	root	_	SpaceAfter=No|Translit=chàbùduō|LTranslit=chàbùduō
@@ -1815,6 +2002,7 @@
 3	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 188
+# parallel_id = hk/188
 # text = 第七題我完成了，直方圖。
 # translit = dìqītíwǒwánchéngle,zhífāngtú.
 1	第七	第七	ADJ	_	_	2	amod	_	SpaceAfter=No|Translit=dìqī|LTranslit=dìqī
@@ -1827,6 +2015,7 @@
 8	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 189
+# parallel_id = hk/189
 # text = 那是直方圖。
 # translit = nàshìzhífāngtú.
 1	那	那	DET	_	_	3	nsubj	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -1835,6 +2024,7 @@
 4	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 190
+# parallel_id = hk/190
 # text = 這個我知道。
 # translit = zhègèwǒzhīdào.
 1	這個	這個	PRON	_	_	3	obj:periph	_	SpaceAfter=No|Translit=zhègè|LTranslit=zhègè
@@ -1843,6 +2033,7 @@
 4	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 191
+# parallel_id = hk/191
 # text = 對了，陳奕迅的新碟你聽過了嗎？
 # translit = duìle,chén奕xùndexīndiénǐtīngguòlema?
 1	對	對	VERB	_	_	0	root	_	SpaceAfter=No|Translit=duì|LTranslit=duì
@@ -1860,6 +2051,7 @@
 13	？	？	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 192
+# parallel_id = hk/192
 # text = 當然有楊千嬅！
 # translit = dāngrányǒuyángqiān嬅!
 1	當然	當然	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=dāngrán|LTranslit=dāngrán
@@ -1868,6 +2060,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 193
+# parallel_id = hk/193
 # text = 他們這麼好朋友。
 # translit = tāmenzhèmehǎopéngyou.
 1	他們	他	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=tāmen|LTranslit=tā
@@ -1877,6 +2070,7 @@
 5	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 194
+# parallel_id = hk/194
 # text = 未聽過？
 # translit = wèitīngguò?
 1	未	未	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
@@ -1885,6 +2079,7 @@
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 195
+# parallel_id = hk/195
 # text = 你等一等。
 # translit = nǐděngyīděng.
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -1892,6 +2087,7 @@
 3	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 196
+# parallel_id = hk/196
 # text = 我播給你聽。
 # translit = wǒbōgěinǐtīng.
 1	我	我	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -1902,12 +2098,14 @@
 6	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 197
+# parallel_id = hk/197
 # text = 黎明？
 # translit = límíng?
 1	黎明	黎明	PROPN	_	_	0	root	_	SpaceAfter=No|Translit=límíng|LTranslit=límíng|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 198
+# parallel_id = hk/198
 # text = 沒品味！
 # translit = méipǐnwèi!
 1	沒	沒	VERB	_	_	0	root	_	SpaceAfter=No|Translit=méi|LTranslit=méi
@@ -1915,6 +2113,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 199
+# parallel_id = hk/199
 # text = 關你什麼事？
 # translit = guānnǐshénmeshì?
 1	關	關	VERB	_	_	0	root	_	SpaceAfter=No|Translit=guān|LTranslit=guān
@@ -1924,6 +2123,7 @@
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 200
+# parallel_id = hk/200
 # text = 喂，你幹麼？
 # translit = wèi,nǐ幹me?
 1	喂	喂	INTJ	_	_	4	discourse	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
@@ -1933,6 +2133,7 @@
 5	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 201
+# parallel_id = hk/201
 # text = 我正在聽的！
 # translit = wǒzhèngzàitīngde!
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -1942,6 +2143,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 202
+# parallel_id = hk/202
 # text = 開電視幹什麼？
 # translit = kāidiànshì幹shénme?
 1	開	開	VERB	_	_	3	advcl	_	SpaceAfter=No|Translit=kāi|LTranslit=kāi
@@ -1951,6 +2153,7 @@
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 203
+# parallel_id = hk/203
 # text = 別阻礙我！
 # translit = biézǔ'àiwǒ!
 1	別	別	AUX	_	_	2	aux	_	SpaceAfter=No|Translit=bié|LTranslit=bié
@@ -1959,12 +2162,14 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 204
+# parallel_id = hk/204
 # text = 閉嘴！
 # translit = bìzuǐ!
 1	閉嘴	閉嘴	VERB	_	_	0	root	_	SpaceAfter=No|Translit=bìzuǐ|LTranslit=bìzuǐ
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 205
+# parallel_id = hk/205
 # text = 我要聽電台！
 # translit = wǒyàotīngdiàntái!
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -1974,6 +2179,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 206
+# parallel_id = hk/206
 # text = 知道了！
 # translit = zhīdàole!
 1	知道	知道	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhīdào|LTranslit=zhīdào
@@ -1981,6 +2187,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 207
+# parallel_id = hk/207
 # text = 那你快坐下然後閉嘴！
 # translit = nànǐkuàizuòxiàránhòubìzuǐ!
 1	那	那	ADV	_	_	4	discourse	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -1993,6 +2200,7 @@
 8	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 208
+# parallel_id = hk/208
 # text = 你很煩！
 # translit = nǐhěnfán!
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -2001,6 +2209,7 @@
 4	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 209
+# parallel_id = hk/209
 # text = 你回去做你的功課吧！
 # translit = nǐhuíqùzuònǐdegōngkèba!
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -2013,6 +2222,7 @@
 8	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 210
+# parallel_id = hk/210
 # text = 去做功課，別吵著我！
 # translit = qùzuògōngkè,biéchǎozhewǒ!
 1	去	去	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qù|LTranslit=qù
@@ -2026,6 +2236,7 @@
 9	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 211
+# parallel_id = hk/211
 # text = 是誰打電話來的？
 # translit = shìshuídǎdiànhuàláide?
 1	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
@@ -2037,6 +2248,7 @@
 7	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 212
+# parallel_id = hk/212
 # text = 關你什麼事？
 # translit = guānnǐshénmeshì?
 1	關	關	VERB	_	_	0	root	_	SpaceAfter=No|Translit=guān|LTranslit=guān
@@ -2046,12 +2258,14 @@
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 213
+# parallel_id = hk/213
 # text = 喂？
 # translit = wèi?
 1	喂	喂	INTJ	_	_	0	root	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 214
+# parallel_id = hk/214
 # text = 聽到嗎？
 # translit = tīngdàoma?
 1	聽	聽	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tīng|LTranslit=tīng|Cxn=Interrogative-Polar-Direct,Resultative|CxnElt=1:Interrogative-Polar-Direct.Clause,1:Resultative.Event
@@ -2060,6 +2274,7 @@
 4	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 215
+# parallel_id = hk/215
 # text = 對啊，這是最新的！
 # translit = duì'a,zhèshìzuìxīnde!
 1	對	對	VERB	_	_	0	root	_	SpaceAfter=No|Translit=duì|LTranslit=duì
@@ -2073,6 +2288,7 @@
 9	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 216
+# parallel_id = hk/216
 # text = 沒聽過吧！
 # translit = méitīngguòba!
 1	沒	沒	PART	_	Polarity=Neg	2	advmod	_	SpaceAfter=No|Translit=méi|LTranslit=méi
@@ -2082,6 +2298,7 @@
 5	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 217
+# parallel_id = hk/217
 # text = 你覺得陳奕迅同楊千嬅最後會一起嗎？
 # translit = nǐjuédechén奕xùntóngyángqiān嬅zuìhòuhuìyīqǐma?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -2096,6 +2313,7 @@
 10	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 218
+# parallel_id = hk/218
 # text = 不是蠻合襯嗎？
 # translit = bùshì蠻héchènma?
 1	不	不	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -2106,6 +2324,7 @@
 6	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 219
+# parallel_id = hk/219
 # text = 你說陳奕迅有什麼不好？
 # translit = nǐshuōchén奕xùnyǒushénmebùhǎo?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -2118,6 +2337,7 @@
 8	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 220
+# parallel_id = hk/220
 # text = 在未有MP3的年代，電台播什麼歌，我們就流行歌。
 # translit = zàiwèiyǒuMP3deniándài,diàntáibōshénmegē,wǒmenjiùliúxínggē.
 1	在	在	ADP	_	_	6	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -2139,6 +2359,7 @@
 17	。	。	PUNCT	_	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 221
+# parallel_id = hk/221
 # text = 在九零三與新城電台間轉來轉去。
 # translit = zàijiǔlíngsānyǔxīnchéngdiàntáijiānzhuǎnláizhuǎnqù.
 1	在	在	ADP	_	_	2	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -2153,6 +2374,7 @@
 10	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 222
+# parallel_id = hk/222
 # text = 阿哥愛聽陳奕迅，我就一起聽陳奕迅。
 # translit = 'āgē'àitīngchén奕xùn,wǒjiùyīqǐtīngchén奕xùn.
 1	阿哥	阿哥	NOUN	_	_	2	nsubj	_	SpaceAfter=No|Translit='āgē|LTranslit='āgē
@@ -2168,6 +2390,7 @@
 11	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 223
+# parallel_id = hk/223
 # text = 要聽歌還可以用十元買一隻雜錦錄音帶，或是花二十元買張盜版。
 # translit = yàotīnggēháikěyǐyòngshíyuánmǎiyī隻zájǐnlùyīndài,huòshìhuā'èrshíyuánmǎizhāngdàobǎn.
 1	要	要	AUX	_	_	2	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
@@ -2194,6 +2417,7 @@
 22	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 224
+# parallel_id = hk/224
 # text = 你自稱是歌迷的話，當然是買華星正版唱片！
 # translit = nǐzìchēngshìgēmídehuà,dāngránshìmǎihuáxīngzhèngbǎnchàngpiàn!
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -2211,6 +2435,7 @@
 13	！	！	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 225
+# parallel_id = hk/225
 # text = 那時候唱片店比現在七十一還要多。
 # translit = nàshíhouchàngpiàndiànbǐxiànzàiqīshíyīháiyàoduō.
 1	那	那	DET	_	_	2	det	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -2226,6 +2451,7 @@
 11	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 226
+# parallel_id = hk/226
 # text = 唱片也跟現在一樣，一張一百元左右。
 # translit = chàngpiànyěgēnxiànzàiyīyàng,yīzhāngyībǎiyuánzuǒyòu.
 1	唱片	唱片	NOUN	_	_	5	nsubj	_	SpaceAfter=No|Translit=chàngpiàn|LTranslit=chàngpiàn
@@ -2242,6 +2468,7 @@
 12	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 227
+# parallel_id = hk/227
 # text = 而且陳奕迅每兩三個月便出一張新唱片。
 # translit = 'érqiěchén奕xùnměiliǎngsāngèyuèbiànchūyīzhāngxīnchàngpiàn.
 1	而且	而且	CCONJ	_	_	9	advmod	_	SpaceAfter=No|Translit='érqiě|LTranslit='érqiě
@@ -2260,6 +2487,7 @@
 14	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 228
+# parallel_id = hk/228
 # text = 但在小時候反而有錢能把想要的唱片都全部購入。
 # translit = dànzàixiǎoshíhoufǎn'éryǒuqiánnéngbǎxiǎngyàodechàngpiàndōuquánbùgòurù.
 1	但	但	CCONJ	_	_	5	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -2280,6 +2508,7 @@
 16	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 229
+# parallel_id = hk/229
 # text = 不懂哥哥什麼叫好品味。
 # translit = bùdǒnggēgēshénmejiàohǎopǐnwèi.
 1	不	不	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -2292,6 +2521,7 @@
 8	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 230
+# parallel_id = hk/230
 # text = 但就是每天也聽個不停。
 # translit = dànjiùshìměitiānyětīnggèbùtíng.
 1	但	但	CCONJ	_	_	3	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -2307,6 +2537,7 @@
 11	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 231
+# parallel_id = hk/231
 # text = 又是只有腸粉！
 # translit = yòushìzhǐyǒuchángfěn!
 1	又	又	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=yòu|LTranslit=yòu
@@ -2316,6 +2547,7 @@
 5	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 232
+# parallel_id = hk/232
 # text = 我要吃蛋撻！
 # translit = wǒyàochīdàn撻!
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -2325,6 +2557,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 233
+# parallel_id = hk/233
 # text = 趕快吃吧！
 # translit = gǎnkuàichība!
 1	趕快	趕快	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=gǎnkuài|LTranslit=gǎnkuài
@@ -2333,6 +2566,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 234
+# parallel_id = hk/234
 # text = 如果阿爺發現我們不在大家樂，就慘了。
 # translit = rúguǒ'āyefāxiànwǒmenbùzàidàjiālè,jiùcǎnle.
 1	如果	如果	SCONJ	_	_	3	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -2349,6 +2583,7 @@
 12	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 235
+# parallel_id = hk/235
 # text = 那些唱片又不是我的！
 # translit = nàxiēchàngpiànyòubùshìwǒde!
 1	那些	那些	DET	_	_	2	det	_	SpaceAfter=No|Translit=nàxiē|LTranslit=nàxiē
@@ -2361,6 +2596,7 @@
 8	！	！	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 236
+# parallel_id = hk/236
 # text = 快把錢還給我！
 # translit = kuàibǎqiánháigěiwǒ!
 1	快	快	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=kuài|LTranslit=kuài
@@ -2372,6 +2608,7 @@
 7	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 237
+# parallel_id = hk/237
 # text = 你沒一起聽嗎？沒一起唱嗎？
 # translit = nǐméiyīqǐtīngma?méiyīqǐchàngma?
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -2387,6 +2624,7 @@
 11	？	？	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 238
+# parallel_id = hk/238
 # text = 兩包腸粉就六元⋯⋯
 # translit = liǎngbāochángfěnjiùliùyuán⋯⋯
 1	兩	兩	NUM	_	_	3	nummod	_	SpaceAfter=No|Translit=liǎng|LTranslit=liǎng
@@ -2398,6 +2636,7 @@
 7	⋯⋯	⋯⋯	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=⋯⋯|LTranslit=⋯⋯
 
 # sent_id = 239
+# parallel_id = hk/239
 # text = 怕了你！
 # translit = pàlenǐ!
 1	怕	怕	VERB	_	_	0	root	_	SpaceAfter=No|Translit=pà|LTranslit=pà
@@ -2406,6 +2645,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 240
+# parallel_id = hk/240
 # text = 給你兩元吧？
 # translit = gěinǐliǎngyuánba?
 1	給	給	VERB	_	_	0	root	_	SpaceAfter=No|Translit=gěi|LTranslit=gěi|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
@@ -2416,6 +2656,7 @@
 6	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 241
+# parallel_id = hk/241
 # text = 不行！
 # translit = bùxíng!
 1	不	不	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -2423,6 +2664,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 242
+# parallel_id = hk/242
 # text = 這樣不公平！
 # translit = zhèyàngbùgōngpíng!
 1	這樣	這樣	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=zhèyàng|LTranslit=zhèyàng
@@ -2431,6 +2673,7 @@
 4	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 243
+# parallel_id = hk/243
 # text = 十元！
 # translit = shíyuán!
 1	十	十	NUM	_	_	2	nummod	_	SpaceAfter=No|Translit=shí|LTranslit=shí
@@ -2438,6 +2681,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 244
+# parallel_id = hk/244
 # text = 五元！
 # translit = wǔyuán!
 1	五	五	NUM	_	_	2	nummod	_	SpaceAfter=No|Translit=wǔ|LTranslit=wǔ
@@ -2445,6 +2689,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 245
+# parallel_id = hk/245
 # text = 不行！
 # translit = bùxíng!
 1	不	不	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -2452,6 +2697,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 246
+# parallel_id = hk/246
 # text = 要不⋯⋯你買新一期Yes!送我。
 # translit = yàobù⋯⋯nǐmǎixīnyīqīYes!sòngwǒ.
 1	要不	要不	ADV	_	_	9	advmod	_	SpaceAfter=No|Translit=yàobù|LTranslit=yàobù
@@ -2467,6 +2713,7 @@
 11	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 247
+# parallel_id = hk/247
 # text = 傻的嗎？
 # translit = shǎdema?
 1	傻	傻	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=shǎ|LTranslit=shǎ|Cxn=Interrogative-Polar-Direct|CxnElt=1:Interrogative-Polar-Direct.Clause
@@ -2475,6 +2722,7 @@
 4	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 248
+# parallel_id = hk/248
 # text = 這麼貴！
 # translit = zhèmeguì!
 1	這麼	這麼	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zhème|LTranslit=zhème
@@ -2482,6 +2730,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 249
+# parallel_id = hk/249
 # text = 你在學校問朋友借來看好了。
 # translit = nǐzàixuéxiàowènpéngyoujièláikànhǎole.
 1	你	你	PRON	_	_	8	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -2496,6 +2745,7 @@
 10	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 250
+# parallel_id = hk/250
 # text = 不行！
 # translit = bùxíng!
 1	不	不	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -2503,6 +2753,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 251
+# parallel_id = hk/251
 # text = 我要跟媽媽說！
 # translit = wǒyàogēnmāmāshuō!
 1	我	我	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -2513,6 +2764,7 @@
 6	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 252
+# parallel_id = hk/252
 # text = 要不這樣，我給你兩元，再給你扭三張Yes!卡。
 # translit = yàobùzhèyàng,wǒgěinǐliǎngyuán,zàigěinǐniǔsānzhāngYes!kǎ.
 1	要不	要不	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=yàobù|LTranslit=yàobù
@@ -2534,6 +2786,7 @@
 17	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 253
+# parallel_id = hk/253
 # text = 這樣可以了吧？
 # translit = zhèyàngkěyǐleba?
 1	這樣	這樣	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zhèyàng|LTranslit=zhèyàng
@@ -2543,6 +2796,7 @@
 5	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 254
+# parallel_id = hk/254
 # text = 好吧！
 # translit = hǎoba!
 1	好	好	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
@@ -2550,6 +2804,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 255
+# parallel_id = hk/255
 # text = 待會兒就去！
 # translit = dàihuìrjiùqù!
 1	待會兒	待會兒	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=dàihuìr|LTranslit=dàihuìr
@@ -2558,6 +2813,7 @@
 4	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 256
+# parallel_id = hk/256
 # text = 快吃吧！
 # translit = kuàichība!
 1	快	快	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=kuài|LTranslit=kuài
@@ -2566,6 +2822,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 257
+# parallel_id = hk/257
 # text = 但是那天，哥哥買回來的竟然不是陳奕迅，而是楊千嬅的唱片。
 # translit = dànshìnàtiān,gēgēmǎihuíláidejìngránbùshìchén奕xùn,'érshìyángqiān嬅dechàngpiàn.
 1	但是	但是	CCONJ	_	_	12	advmod	_	SpaceAfter=No|Translit=dànshì|LTranslit=dànshì
@@ -2589,6 +2846,7 @@
 19	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 258
+# parallel_id = hk/258
 # text = 家中還出現了一本Yes!。
 # translit = jiāzhōngháichūxiànleyīběnYes!.
 1	家	家	NOUN	_	_	4	obl	_	SpaceAfter=No|Translit=jiā|LTranslit=jiā
@@ -2602,6 +2860,7 @@
 9	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 259
+# parallel_id = hk/259
 # text = 我還以為哥哥對我這樣好。
 # translit = wǒháiyǐwèigēgēduìwǒzhèyànghǎo.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -2615,6 +2874,7 @@
 9	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 260
+# parallel_id = hk/260
 # text = 隔天我拿著本破破爛爛的Yes!，問他封面去了哪裡去。
 # translit = gétiānwǒnázheběnpòpòlànlàndeYes!,wèntāfēngmiànqùlenǎliqù.
 1	隔	隔	VERB	_	_	2	advcl	_	SpaceAfter=No|Translit=gé|LTranslit=gé
@@ -2637,6 +2897,7 @@
 18	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 261
+# parallel_id = hk/261
 # text = 那時候我才明白他的好品味不是陳奕迅。
 # translit = nàshíhouwǒcáimíngbáitādehǎopǐnwèibùshìchén奕xùn.
 1	那	那	DET	_	_	2	det	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -2654,6 +2915,7 @@
 13	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 262
+# parallel_id = hk/262
 # text = 應該也不是楊千嬅。
 # translit = yīnggāiyěbùshìyángqiān嬅.
 1	應該	應該	AUX	_	_	5	aux	_	SpaceAfter=No|Translit=yīnggāi|LTranslit=yīnggāi
@@ -2664,6 +2926,7 @@
 6	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 263
+# parallel_id = hk/263
 # text = 我不懂你們說的什麼品味。
 # translit = wǒbùdǒngnǐmenshuōdeshénmepǐnwèi.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -2677,6 +2940,7 @@
 9	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 264
+# parallel_id = hk/264
 # text = 這些流行曲我不懂欣賞。
 # translit = zhèxiēliúxíngqūwǒbùdǒngxīnshǎng.
 1	這些	這些	DET	_	_	2	det	_	SpaceAfter=No|Translit=zhèxiē|LTranslit=zhèxiē
@@ -2688,6 +2952,7 @@
 7	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 265
+# parallel_id = hk/265
 # text = 都不知有什麼好聽。
 # translit = dōubùzhīyǒushénmehǎotīng.
 1	都	都	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=dōu|LTranslit=dōu
@@ -2700,6 +2965,7 @@
 8	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 266
+# parallel_id = hk/266
 # text = 不知道呢。
 # translit = bùzhīdàone.
 1	不	不	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -2708,12 +2974,14 @@
 4	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 267
+# parallel_id = hk/267
 # text = 哦。
 # translit = 'ó.
 1	哦	哦	INTJ	_	_	0	root	_	SpaceAfter=No|Translit='ó|LTranslit='ó
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 268
+# parallel_id = hk/268
 # text = 要用三角形內角總和嗎？
 # translit = yàoyòngsānjiǎoxíngnèijiǎozǒnghéma?
 1	要	要	AUX	_	_	2	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
@@ -2723,12 +2991,14 @@
 5	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 269
+# parallel_id = hk/269
 # text = 哦。
 # translit = 'ó.
 1	哦	哦	INTJ	_	_	0	root	_	SpaceAfter=No|Translit='ó|LTranslit='ó
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 270
+# parallel_id = hk/270
 # text = 你完成了？
 # translit = nǐwánchéngle?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -2737,6 +3007,7 @@
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 271
+# parallel_id = hk/271
 # text = 真羨慕！
 # translit = zhēnxiànmù!
 1	真	真	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zhēn|LTranslit=zhēn
@@ -2744,6 +3015,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 272
+# parallel_id = hk/272
 # text = 我還有很多未做好。
 # translit = wǒháiyǒuhěnduōwèizuòhǎo.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -2757,6 +3029,7 @@
 9	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 273
+# parallel_id = hk/273
 # text = 你來教我吧。
 # translit = nǐláijiàowǒba.
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -2767,6 +3040,7 @@
 6	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 274
+# parallel_id = hk/274
 # text = 你可以閉嘴嗎？
 # translit = nǐkěyǐbìzuǐma?
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -2776,6 +3050,7 @@
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 275
+# parallel_id = hk/275
 # text = 我正錄英文功課！
 # translit = wǒzhènglùyīngwéngōngkè!
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -2786,6 +3061,7 @@
 6	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 276
+# parallel_id = hk/276
 # text = 你等等我。
 # translit = nǐděngděngwǒ.
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -2794,6 +3070,7 @@
 4	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 277
+# parallel_id = hk/277
 # text = 我也要問功課！
 # translit = wǒyěyàowèngōngkè!
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -2804,6 +3081,7 @@
 6	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 278
+# parallel_id = hk/278
 # text = 不是只有你有功課做！
 # translit = bùshìzhǐyǒunǐyǒugōngkèzuò!
 1	不	不	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -2817,12 +3095,14 @@
 9	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 279
+# parallel_id = hk/279
 # text = 以大欺小！。
 # translit = yǐdàqīxiǎo!.
 1	以大欺小！	以大欺小！	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǐdàqīxiǎo!|LTranslit=yǐdàqīxiǎo!
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 280
+# parallel_id = hk/280
 # text = 你先做其他功課吧！
 # translit = nǐxiānzuòqítāgōngkèba!
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -2834,6 +3114,7 @@
 7	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 281
+# parallel_id = hk/281
 # text = 我只差這一份！
 # translit = wǒzhǐchàzhèyīfèn!
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -2845,6 +3126,7 @@
 7	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 282
+# parallel_id = hk/282
 # text = 八號要交了！
 # translit = bāhàoyàojiāole!
 1	八號	八號	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No|Translit=bāhào|LTranslit=bāhào
@@ -2854,6 +3136,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 283
+# parallel_id = hk/283
 # text = 你等等。
 # translit = nǐděngděng.
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -2861,6 +3144,7 @@
 3	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 284
+# parallel_id = hk/284
 # text = 怕了你！
 # translit = pàlenǐ!
 1	怕	怕	VERB	_	_	0	root	_	SpaceAfter=No|Translit=pà|LTranslit=pà
@@ -2869,6 +3153,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 285
+# parallel_id = hk/285
 # text = 等一下。
 # translit = děngyīxià.
 1	等	等	VERB	_	_	0	root	_	SpaceAfter=No|Translit=děng|LTranslit=děng
@@ -2876,12 +3161,14 @@
 3	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 286
+# parallel_id = hk/286
 # text = 喂？
 # translit = wèi?
 1	喂	喂	INTJ	_	_	0	root	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 287
+# parallel_id = hk/287
 # text = 我妹妹有功課不會。
 # translit = wǒmèimèiyǒugōngkèbùhuì.
 1	我	我	PRON	_	_	2	nmod	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -2893,6 +3180,7 @@
 7	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 288
+# parallel_id = hk/288
 # text = 我想先教教她。
 # translit = wǒxiǎngxiānjiàojiàotā.
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -2903,6 +3191,7 @@
 6	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 289
+# parallel_id = hk/289
 # text = 對，她有點煩人。
 # translit = duì,tāyǒudiǎnfánrén.
 1	對	對	VERB	_	_	0	root	_	SpaceAfter=No|Translit=duì|LTranslit=duì
@@ -2913,6 +3202,7 @@
 6	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 290
+# parallel_id = hk/290
 # text = 待會兒我再打給你！
 # translit = dàihuìrwǒzàidǎgěinǐ!
 1	待會兒	待會兒	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=dàihuìr|LTranslit=dàihuìr
@@ -2924,6 +3214,7 @@
 7	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 291
+# parallel_id = hk/291
 # text = 那題我明白了。
 # translit = nàtíwǒmíngbáile.
 1	那	那	DET	_	_	2	det	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -2934,6 +3225,7 @@
 6	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 292
+# parallel_id = hk/292
 # text = 好的，再見！
 # translit = hǎode,zàijiàn!
 1	好	好	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
@@ -2943,6 +3235,7 @@
 5	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 293
+# parallel_id = hk/293
 # text = 喂！借盒錄音帶給我。
 # translit = wèi!jièhélùyīndàigěiwǒ.
 1	喂	喂	INTJ	_	_	3	discourse	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
@@ -2955,6 +3248,7 @@
 8	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 294
+# parallel_id = hk/294
 # text = 不要！
 # translit = bùyào!
 1	不	不	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -2962,6 +3256,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 295
+# parallel_id = hk/295
 # text = 為什麼要借給你？
 # translit = wèishénmeyàojiègěinǐ?
 1	為什麼	為什麼	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=wèishénme|LTranslit=wèishénme|CxnElt=3:Interrogative-WHInfo-Direct.WHWord
@@ -2972,6 +3267,7 @@
 6	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 296
+# parallel_id = hk/296
 # text = 我有朋友八號生日！
 # translit = wǒyǒupéngyoubāhàoshēngrì!
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -2982,6 +3278,7 @@
 6	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 297
+# parallel_id = hk/297
 # text = 我想錄些東西給她。
 # translit = wǒxiǎnglùxiēdōngxigěitā.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -2994,6 +3291,7 @@
 8	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 298
+# parallel_id = hk/298
 # text = 關我什麼事？
 # translit = guānwǒshénmeshì?
 1	關	關	VERB	_	_	0	root	_	SpaceAfter=No|Translit=guān|LTranslit=guān
@@ -3003,6 +3301,7 @@
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 299
+# parallel_id = hk/299
 # text = 喂，關係到將來你有沒有利是錢收。
 # translit = wèi,guānxìdàojiāngláinǐyǒuméiyǒulìshìqiánshōu.
 1	喂	喂	INTJ	_	_	3	discourse	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
@@ -3018,12 +3317,14 @@
 11	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 300
+# parallel_id = hk/300
 # text = 喂！
 # translit = wèi!
 1	喂	喂	INTJ	_	_	0	root	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 301
+# parallel_id = hk/301
 # text = 嚇死人了！
 # translit = xiàsǐrénle!
 1	嚇	嚇	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xià|LTranslit=xià|Cxn=Resultative|CxnElt=1:Resultative.Event
@@ -3033,6 +3334,7 @@
 5	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 302
+# parallel_id = hk/302
 # text = 你在幹麼？
 # translit = nǐzài幹me?
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -3041,6 +3343,7 @@
 4	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 303
+# parallel_id = hk/303
 # text = 你專心刷牙啦！
 # translit = nǐzhuānxīnshuāyála!
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -3050,6 +3353,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 304
+# parallel_id = hk/304
 # text = 滴到四周也有！
 # translit = dīdàosìzhōuyěyǒu!
 1	滴	滴	VERB	_	_	0	root	_	SpaceAfter=No|Translit=dī|LTranslit=dī
@@ -3060,6 +3364,7 @@
 6	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 305
+# parallel_id = hk/305
 # text = 刷好快些去睡！
 # translit = shuāhǎokuàixiēqùshuì!
 1	刷	刷	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shuā|LTranslit=shuā|Cxn=Resultative|CxnElt=1:Resultative.Event
@@ -3071,12 +3376,14 @@
 7	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 306
+# parallel_id = hk/306
 # text = 來！
 # translit = lái!
 1	來	來	VERB	_	_	0	root	_	SpaceAfter=No|Translit=lái|LTranslit=lái
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 307
+# parallel_id = hk/307
 # text = 又怎麼了？
 # translit = yòuzěnmele?
 1	又	又	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=yòu|LTranslit=yòu
@@ -3085,6 +3392,7 @@
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 308
+# parallel_id = hk/308
 # text = 別吵！
 # translit = biéchǎo!
 1	別	別	AUX	_	_	2	aux	_	SpaceAfter=No|Translit=bié|LTranslit=bié
@@ -3092,6 +3400,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 309
+# parallel_id = hk/309
 # text = 小心吵醒爺爺！
 # translit = xiǎoxīnchǎoxǐngyeye!
 1	小心	小心	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=xiǎoxīn|LTranslit=xiǎoxīn
@@ -3101,6 +3410,7 @@
 5	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 310
+# parallel_id = hk/310
 # text = 那你要幹麼？
 # translit = nànǐyào幹me?
 1	那	那	DET	_	_	4	discourse	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -3110,12 +3420,14 @@
 5	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 311
+# parallel_id = hk/311
 # text = 計數！！
 # translit = jìshù!!
 1	計數！	計數！	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jìshù!|LTranslit=jìshù!
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 312
+# parallel_id = hk/312
 # text = 記著，每一面三十分鐘。
 # translit = jìzhe,měiyīmiànsānshífēnzhōng.
 1	記	記	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jì|LTranslit=jì
@@ -3129,6 +3441,7 @@
 9	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 313
+# parallel_id = hk/313
 # text = 我選歌，你計數。
 # translit = wǒxuǎngē,nǐjìshù.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -3140,6 +3453,7 @@
 7	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 314
+# parallel_id = hk/314
 # text = 中間不要有空白，明白嗎？
 # translit = zhōngjiānbùyàoyǒukōngbái,míngbáima?
 1	中間	中間	NOUN	_	_	4	obl	_	SpaceAfter=No|Translit=zhōngjiān|LTranslit=zhōngjiān
@@ -3153,6 +3467,7 @@
 9	？	？	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 315
+# parallel_id = hk/315
 # text = 對我有什麼好處？
 # translit = duìwǒyǒushénmehǎochù?
 1	對	對	ADP	_	_	2	case	_	SpaceAfter=No|Translit=duì|LTranslit=duì
@@ -3163,6 +3478,7 @@
 6	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 316
+# parallel_id = hk/316
 # text = 你不幫？
 # translit = nǐbùbāng?
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -3171,6 +3487,7 @@
 4	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 317
+# parallel_id = hk/317
 # text = 打你一身！
 # translit = dǎnǐyīshēn!
 1	打	打	VERB	_	_	0	root	_	SpaceAfter=No|Translit=dǎ|LTranslit=dǎ
@@ -3180,6 +3497,7 @@
 5	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 318
+# parallel_id = hk/318
 # text = 記下，第一首，《抬起我的頭來》，三分二十一秒。
 # translit = jìxià,dìyīshǒu,«táiqǐwǒdetóulái»,sānfēn'èrshíyīmiǎo.
 1	記	記	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jì|LTranslit=jì
@@ -3199,12 +3517,14 @@
 15	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 319
+# parallel_id = hk/319
 # text = 等等！
 # translit = děngděng!
 1	等等	等等	VERB	_	_	0	root	_	SpaceAfter=No|Translit=děngděng|LTranslit=děngděng
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 320
+# parallel_id = hk/320
 # text = 第二首。
 # translit = dì'èrshǒu.
 1	第二	第二	ADJ	_	_	2	amod	_	SpaceAfter=No|Translit=dì'èr|LTranslit=dì'èr
@@ -3212,12 +3532,14 @@
 3	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 321
+# parallel_id = hk/321
 # text = 等等！
 # translit = děngděng!
 1	等等	等等	VERB	_	_	0	root	_	SpaceAfter=No|Translit=děngděng|LTranslit=děngděng
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 322
+# parallel_id = hk/322
 # text = 《黑夜不再來》
 # translit = «hēiyèbùzàilái»
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -3225,6 +3547,7 @@
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=»|LTranslit=»
 
 # sent_id = 323
+# parallel_id = hk/323
 # text = 等一等呀！
 # translit = děngyīděngya!
 1	等一等	等一等	VERB	_	_	0	root	_	SpaceAfter=No|Translit=děngyīděng|LTranslit=děngyīděng
@@ -3232,6 +3555,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 324
+# parallel_id = hk/324
 # text = 四分五秒。
 # translit = sìfēnwǔmiǎo.
 1	四	四	NUM	_	_	2	nummod	_	SpaceAfter=No|Translit=sì|LTranslit=sì
@@ -3241,12 +3565,14 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 325
+# parallel_id = hk/325
 # text = 等等！
 # translit = děngděng!
 1	等等	等等	VERB	_	_	0	root	_	SpaceAfter=No|Translit=děngděng|LTranslit=děngděng
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 326
+# parallel_id = hk/326
 # text = 第一首有多長？
 # translit = dìyīshǒuyǒuduōzhǎng?
 1	第一	第一	ADJ	_	_	2	amod	_	SpaceAfter=No|Translit=dìyī|LTranslit=dìyī
@@ -3257,6 +3583,7 @@
 6	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 327
+# parallel_id = hk/327
 # text = 三分二十一呀。
 # translit = sānfēn'èrshíyīya.
 1	三	三	NUM	_	_	2	nummod	_	SpaceAfter=No|Translit=sān|LTranslit=sān
@@ -3266,6 +3593,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 328
+# parallel_id = hk/328
 # text = 什麼來的？
 # translit = shénmeláide?
 1	什麼	什麼	DET	_	_	0	root	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
@@ -3274,6 +3602,7 @@
 4	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 329
+# parallel_id = hk/329
 # text = 《夏天的故事》之後，哥哥沒再買過陳奕迅以外的唱片。
 # translit = «xiàtiāndegùshì»zhīhòu,gēgēméizàimǎiguòchén奕xùnyǐwàidechàngpiàn.
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -3293,6 +3622,7 @@
 15	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 330
+# parallel_id = hk/330
 # text = 其實我也不明白，哥哥為何不直接送楊千嬅的唱片給他朋友。
 # translit = qíshíwǒyěbùmíngbái,gēgēwèihébùzhíjiēsòngyángqiān嬅dechàngpiàngěitāpéngyou.
 1	其實	其實	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=qíshí|LTranslit=qíshí
@@ -3315,6 +3645,7 @@
 18	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 331
+# parallel_id = hk/331
 # text = 但我覺得那一晚，我們幹了一場很帥很浪漫的事情。
 # translit = dànwǒjuédenàyīwǎn,wǒmen幹leyīchǎnghěnshuàihěnlàngmàndeshìqíng.
 1	但	但	CCONJ	_	_	3	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -3338,6 +3669,7 @@
 19	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 332
+# parallel_id = hk/332
 # text = 收拾好！
 # translit = shōushihǎo!
 1	收拾	收拾	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shōushi|LTranslit=shōushi|Cxn=Resultative|CxnElt=1:Resultative.Event
@@ -3345,6 +3677,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 333
+# parallel_id = hk/333
 # text = 我要聽《森美小儀dotdotdot》！
 # translit = wǒyàotīng«sēnměixiǎoyídotdotdot»!
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -3356,6 +3689,7 @@
 7	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 334
+# parallel_id = hk/334
 # text = 快轉到九零三！
 # translit = kuàizhuǎndàojiǔlíngsān!
 1	快	快	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=kuài|LTranslit=kuài
@@ -3365,6 +3699,7 @@
 5	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 335
+# parallel_id = hk/335
 # text = 等等吧！
 # translit = děngděngba!
 1	等等	等等	VERB	_	_	0	root	_	SpaceAfter=No|Translit=děngděng|LTranslit=děngděng
@@ -3372,6 +3707,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 336
+# parallel_id = hk/336
 # text = 快些吧！
 # translit = kuàixiēba!
 1	快	快	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=kuài|LTranslit=kuài
@@ -3380,6 +3716,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 337
+# parallel_id = hk/337
 # text = 這首你剛剛才錄了。
 # translit = zhèshǒunǐgānggāngcáilùle.
 1	這	這	DET	_	_	2	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -3392,6 +3729,7 @@
 8	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 338
+# parallel_id = hk/338
 # text = 又聽？
 # translit = yòutīng?
 1	又	又	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=yòu|LTranslit=yòu
@@ -3399,6 +3737,7 @@
 3	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 339
+# parallel_id = hk/339
 # text = 這就是九零三。
 # translit = zhèjiùshìjiǔlíngsān.
 1	這	這	DET	_	_	4	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -3408,6 +3747,7 @@
 5	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 340
+# parallel_id = hk/340
 # text = 你自己看看吧。
 # translit = nǐzìjǐkànkànba.
 1	你自己	你自己	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐzìjǐ|LTranslit=nǐzìjǐ
@@ -3416,6 +3756,7 @@
 4	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 341
+# parallel_id = hk/341
 # text = 接收不到，你弄壞了。
 # translit = jiēshōubùdào,nǐnònghuàile.
 1	接收	接收	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jiēshōu|LTranslit=jiēshōu|Cxn=Resultative|CxnElt=1:Resultative.Event
@@ -3429,6 +3770,7 @@
 9	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 342
+# parallel_id = hk/342
 # text = 你快弄好回來呀。
 # translit = nǐkuàinònghǎohuíláiya.
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -3440,6 +3782,7 @@
 7	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 343
+# parallel_id = hk/343
 # text = 到那邊試試。
 # translit = dàonàbiānshìshì.
 1	到	到	ADP	_	_	3	case	_	SpaceAfter=No|Translit=dào|LTranslit=dào
@@ -3449,6 +3792,7 @@
 5	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 344
+# parallel_id = hk/344
 # text = 仍接收不到。
 # translit = réngjiēshōubùdào.
 1	仍	仍	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=réng|LTranslit=réng
@@ -3458,6 +3802,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 345
+# parallel_id = hk/345
 # text = 舉高收音機。
 # translit = jǔgāoshōuyīnjī.
 1	舉	舉	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jǔ|LTranslit=jǔ|Cxn=Resultative|CxnElt=1:Resultative.Event
@@ -3466,6 +3811,7 @@
 4	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 346
+# parallel_id = hk/346
 # text = 你試試把天線伸到窗邊。
 # translit = nǐshìshìbǎtiānxiànshēndàochuāngbiān.
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -3479,6 +3825,7 @@
 9	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 347
+# parallel_id = hk/347
 # text = 還是沒反應。
 # translit = háishìméifǎnyīng.
 1	還是	還是	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=háishì|LTranslit=háishì
@@ -3487,6 +3834,7 @@
 4	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 348
+# parallel_id = hk/348
 # text = 你走到另一邊試試。
 # translit = nǐzǒudàolìngyībiānshìshì.
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -3499,6 +3847,7 @@
 8	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 349
+# parallel_id = hk/349
 # text = 轉個圈看看。
 # translit = zhuǎngèquānkànkàn.
 1	轉	轉	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhuǎn|LTranslit=zhuǎn
@@ -3508,6 +3857,7 @@
 5	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 350
+# parallel_id = hk/350
 # text = 跳兩步。
 # translit = tiàoliǎngbù.
 1	跳	跳	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tiào|LTranslit=tiào
@@ -3516,6 +3866,7 @@
 4	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 351
+# parallel_id = hk/351
 # text = 再舉高試試收不收到。
 # translit = zàijǔgāoshìshìshōubùshōudào.
 1	再	再	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -3529,6 +3880,7 @@
 9	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 352
+# parallel_id = hk/352
 # text = 再舉高。
 # translit = zàijǔgāo.
 1	再	再	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -3537,6 +3889,7 @@
 4	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 353
+# parallel_id = hk/353
 # text = 再高一些！
 # translit = zàigāoyīxiē!
 1	再	再	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -3545,6 +3898,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 354
+# parallel_id = hk/354
 # text = 你要我試多少次才行？
 # translit = nǐyàowǒshìduōshǎocìcáixíng?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -3558,6 +3912,7 @@
 9	？	？	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 355
+# parallel_id = hk/355
 # text = 很重啊！
 # translit = hěnzhòng'a!
 1	很	很	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=hěn|LTranslit=hěn
@@ -3566,6 +3921,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 356
+# parallel_id = hk/356
 # text = 你最後一個踫它。
 # translit = nǐzuìhòuyīgè踫tā.
 1	你	你	PRON	_	_	6	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -3578,6 +3934,7 @@
 8	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 357
+# parallel_id = hk/357
 # text = 是你弄壞的。
 # translit = shìnǐnònghuàide.
 1	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
@@ -3588,6 +3945,7 @@
 6	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 358
+# parallel_id = hk/358
 # text = 你要負責弄好。
 # translit = nǐyàofùzénònghǎo.
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -3598,6 +3956,7 @@
 6	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 359
+# parallel_id = hk/359
 # text = 關我什麼事？
 # translit = guānwǒshénmeshì?
 1	關	關	ADP	_	_	0	root	_	SpaceAfter=No|Translit=guān|LTranslit=guān
@@ -3607,6 +3966,7 @@
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 360
+# parallel_id = hk/360
 # text = 這句有效！
 # translit = zhèjùyǒuxiào!
 1	這	這	DET	_	_	2	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -3615,6 +3975,7 @@
 4	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 361
+# parallel_id = hk/361
 # text = 繼續說！
 # translit = jìxùshuō!
 1	繼續	繼續	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jìxù|LTranslit=jìxù
@@ -3622,6 +3983,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 362
+# parallel_id = hk/362
 # text = 關我什麼事？
 # translit = guānwǒshénmeshì?
 1	關	關	ADP	_	_	0	root	_	SpaceAfter=No|Translit=guān|LTranslit=guān
@@ -3631,6 +3993,7 @@
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 363
+# parallel_id = hk/363
 # text = 說快一點！
 # translit = shuōkuàiyīdiǎn!
 1	說	說	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shuō|LTranslit=shuō|Cxn=Resultative|CxnElt=1:Resultative.Event
@@ -3639,6 +4002,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 364
+# parallel_id = hk/364
 # text = 關我什麼事？
 # translit = guānwǒshénmeshì?
 1	關	關	ADP	_	_	0	root	_	SpaceAfter=No|Translit=guān|LTranslit=guān
@@ -3648,6 +4012,7 @@
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 365
+# parallel_id = hk/365
 # text = 再快，要更快！
 # translit = zàikuài,yàogèngkuài!
 1	再	再	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -3659,6 +4024,7 @@
 7	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 366
+# parallel_id = hk/366
 # text = 關我什麼事？
 # translit = guānwǒshénmeshì?
 1	關	關	ADP	_	_	0	root	_	SpaceAfter=No|Translit=guān|LTranslit=guān
@@ -3668,12 +4034,14 @@
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 367
+# parallel_id = hk/367
 # text = 喂！
 # translit = wèi!
 1	喂	喂	INTJ	_	_	0	root	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 368
+# parallel_id = hk/368
 # text = 有什麼好笑？
 # translit = yǒushénmehǎoxiào?
 1	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred,Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause
@@ -3683,6 +4051,7 @@
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 369
+# parallel_id = hk/369
 # text = 小聲一點！
 # translit = xiǎoshēngyīdiǎn!
 1	小聲	小聲	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=xiǎoshēng|LTranslit=xiǎoshēng
@@ -3690,6 +4059,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 370
+# parallel_id = hk/370
 # text = 吵醒人啦！
 # translit = chǎoxǐngrénla!
 1	吵	吵	VERB	_	_	0	root	_	SpaceAfter=No|Translit=chǎo|LTranslit=chǎo|Cxn=Resultative|CxnElt=1:Resultative.Event
@@ -3699,6 +4069,7 @@
 5	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 371
+# parallel_id = hk/371
 # text = 小聲一點！
 # translit = xiǎoshēngyīdiǎn!
 1	小聲	小聲	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=xiǎoshēng|LTranslit=xiǎoshēng
@@ -3706,6 +4077,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 372
+# parallel_id = hk/372
 # text = 你的拖鞋聲很吵！
 # translit = nǐdetuōxiéshēnghěnchǎo!
 1	你	你	PRON	_	_	3	nmod	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -3716,6 +4088,7 @@
 6	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 373
+# parallel_id = hk/373
 # text = 別吵了！
 # translit = biéchǎole!
 1	別	別	AUX	_	_	2	aux	_	SpaceAfter=No|Translit=bié|LTranslit=bié
@@ -3724,6 +4097,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 374
+# parallel_id = hk/374
 # text = 難度要我不穿拖鞋嗎？
 # translit = nándùyàowǒbùchuāntuōxiéma?
 1	難度	難度	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=nándù|LTranslit=nándù
@@ -3736,12 +4110,14 @@
 8	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 375
+# parallel_id = hk/375
 # text = 什麼？
 # translit = shénme?
 1	什麼	什麼	PRON	_	_	0	root	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 376
+# parallel_id = hk/376
 # text = 難度要我不穿拖鞋嗎？
 # translit = nándùyàowǒbùchuāntuōxiéma?
 1	難度	難度	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=nándù|LTranslit=nándù
@@ -3754,6 +4130,7 @@
 8	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 377
+# parallel_id = hk/377
 # text = 你再大聲說話小心爺爺起床打你，知道嗎？
 # translit = nǐzàidàshēngshuōhuàxiǎoxīnyeyeqǐchuángdǎnǐ,zhīdàoma?
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -3771,6 +4148,7 @@
 13	？	？	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 378
+# parallel_id = hk/378
 # text = 不知道。
 # translit = bùzhīdào.
 1	不	不	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -3778,6 +4156,7 @@
 3	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 379
+# parallel_id = hk/379
 # text = 你想我代爺爺打你嗎？
 # translit = nǐxiǎngwǒdàiyeyedǎnǐma?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -3791,6 +4170,7 @@
 9	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 380
+# parallel_id = hk/380
 # text = 還敢吵嗎？
 # translit = háigǎnchǎoma?
 1	還	還	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=hái|LTranslit=hái
@@ -3800,6 +4180,7 @@
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 381
+# parallel_id = hk/381
 # text = 乖乖坐下吧！
 # translit = guāiguāizuòxiàba!
 1	乖乖	乖乖	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=guāiguāi|LTranslit=guāiguāi
@@ -3809,6 +4190,7 @@
 5	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 382
+# parallel_id = hk/382
 # text = 不要。
 # translit = bùyào.
 1	不	不	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -3816,12 +4198,14 @@
 3	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 383
+# parallel_id = hk/383
 # text = 臭小鬼！
 # translit = chòuxiǎoguǐ!
 1	臭小鬼	臭小鬼	NOUN	_	_	0	root	_	SpaceAfter=No|Translit=chòuxiǎoguǐ|LTranslit=chòuxiǎoguǐ
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 384
+# parallel_id = hk/384
 # text = 真的要我出手才行？
 # translit = zhēndeyàowǒchūshǒucáixíng?
 1	真的	真的	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=zhēnde|LTranslit=zhēnde
@@ -3833,6 +4217,7 @@
 7	？	？	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 385
+# parallel_id = hk/385
 # text = 快拿起收音機再跳！
 # translit = kuàináqǐshōuyīnjīzàitiào!
 1	快	快	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=kuài|LTranslit=kuài
@@ -3844,6 +4229,7 @@
 7	！	！	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 386
+# parallel_id = hk/386
 # text = 我今天扭到的！
 # translit = wǒjīntiānniǔdàode!
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -3854,6 +4240,7 @@
 6	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 387
+# parallel_id = hk/387
 # text = 我送給你再送給你的朋友！
 # translit = wǒsònggěinǐzàisònggěinǐdepéngyou!
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -3869,6 +4256,7 @@
 11	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 388
+# parallel_id = hk/388
 # text = 幫我跟她說聲「生日快樂」！
 # translit = bāngwǒgēntāshuōshēng‘shēngrìkuàilè’!
 1	幫	幫	VERB	_	_	0	root	_	SpaceAfter=No|Translit=bāng|LTranslit=bāng
@@ -3883,6 +4271,7 @@
 10	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 389
+# parallel_id = hk/389
 # text = 不用了。
 # translit = bùyòngle.
 1	不用	用	AUX	_	Polarity=Neg	0	root	_	SpaceAfter=No|Translit=bùyòng|LTranslit=yòng
@@ -3890,6 +4279,7 @@
 3	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 390
+# parallel_id = hk/390
 # text = 喂，我特意跟朋友交換回來的！
 # translit = wèi,wǒtèyìgēnpéngyoujiāohuànhuíláide!
 1	喂	喂	INTJ	_	_	7	discourse	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
@@ -3904,6 +4294,7 @@
 10	！	！	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 391
+# parallel_id = hk/391
 # text = 已經是千禧年了，沒有人會再聽錄音帶！
 # translit = yǐjīngshìqiān禧niánle,méiyǒurénhuìzàitīnglùyīndài!
 1	已經	已經	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=yǐjīng|LTranslit=yǐjīng
@@ -3920,12 +4311,14 @@
 12	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 392
+# parallel_id = hk/392
 # text = 傻瓜！
 # translit = shǎguā!
 1	傻瓜	傻瓜	NOUN	_	_	0	root	_	SpaceAfter=No|Translit=shǎguā|LTranslit=shǎguā
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 393
+# parallel_id = hk/393
 # text = 就是這一盒？
 # translit = jiùshìzhèyīhé?
 1	就	就	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=jiù|LTranslit=jiù
@@ -3936,6 +4329,7 @@
 6	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 394
+# parallel_id = hk/394
 # text = 對了，對了！
 # translit = duìle,duìle!
 1	對	對	VERB	_	_	0	root	_	SpaceAfter=No|Translit=duì|LTranslit=duì
@@ -3946,6 +4340,7 @@
 6	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 395
+# parallel_id = hk/395
 # text = 《抬起我的頭來》
 # translit = «táiqǐwǒdetóulái»
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -3953,6 +4348,7 @@
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=»|LTranslit=»
 
 # sent_id = 396
+# parallel_id = hk/396
 # text = 《今天等我來》
 # translit = «jīntiānděngwǒlái»
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -3960,6 +4356,7 @@
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=»|LTranslit=»
 
 # sent_id = 397
+# parallel_id = hk/397
 # text = 《不再讓你孤單》
 # translit = «bùzàiràngnǐgūdān»
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -3967,6 +4364,7 @@
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=»|LTranslit=»
 
 # sent_id = 398
+# parallel_id = hk/398
 # text = 《今日》
 # translit = «jīnrì»
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -3974,6 +4372,7 @@
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=»|LTranslit=»
 
 # sent_id = 399
+# parallel_id = hk/399
 # text = 《每一個明天》
 # translit = «měiyīgèmíngtiān»
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -3981,6 +4380,7 @@
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=»|LTranslit=»
 
 # sent_id = 400
+# parallel_id = hk/400
 # text = 《夏天的故事》
 # translit = «xiàtiāndegùshì»
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -3988,6 +4388,7 @@
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=»|LTranslit=»
 
 # sent_id = 401
+# parallel_id = hk/401
 # text = 《伴遊》
 # translit = «bànyóu»
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -3995,6 +4396,7 @@
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=»|LTranslit=»
 
 # sent_id = 402
+# parallel_id = hk/402
 # text = 《與我常在》
 # translit = «yǔwǒchángzài»
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -4002,6 +4404,7 @@
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=»|LTranslit=»
 
 # sent_id = 403
+# parallel_id = hk/403
 # text = 《有發生過》
 # translit = «yǒufāshēngguò»
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -4009,6 +4412,7 @@
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=»|LTranslit=»
 
 # sent_id = 404
+# parallel_id = hk/404
 # text = 什麼？童年經典──《龍珠》主題曲。
 # translit = shénme?tóngniánjīngdiǎn──«lóngzhū»zhǔtíqū.
 1	什麼	什麼	PRON	_	_	0	root	_	SpaceAfter=No|Translit=shénme|LTranslit=shénme|Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
@@ -4023,6 +4427,7 @@
 10	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 405
+# parallel_id = hk/405
 # text = 難怪那時他追不到那女孩！
 # translit = nánguàinàshítāzhuībùdàonànǚhái!
 1	難怪	難怪	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=nánguài|LTranslit=nánguài
@@ -4036,6 +4441,7 @@
 9	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 406
+# parallel_id = hk/406
 # text = 那部機還在嗎？
 # translit = nàbùjīháizàima?
 1	那	那	DET	_	_	3	det	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -4047,6 +4453,7 @@
 7	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 407
+# parallel_id = hk/407
 # text = 有了。
 # translit = yǒule.
 1	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
@@ -4054,6 +4461,7 @@
 3	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 408
+# parallel_id = hk/408
 # text = 竟然能找到！
 # translit = jìngránnéngzhǎodào!
 1	竟然	竟然	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=jìngrán|LTranslit=jìngrán
@@ -4063,6 +4471,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 409
+# parallel_id = hk/409
 # text = 怎會是這樣的？
 # translit = zěnhuìshìzhèyàngde?
 1	怎	怎	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=zěn|LTranslit=zěn|CxnElt=4:Interrogative-WHInfo-Direct.WHWord
@@ -4073,6 +4482,7 @@
 6	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 410
+# parallel_id = hk/410
 # text = 他總是在欺負我！
 # translit = tāzǒngshìzàiqīfùwǒ!
 1	他	他	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -4083,6 +4493,7 @@
 6	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 411
+# parallel_id = hk/411
 # text = 每一個歌手都有一個藝名的。
 # translit = měiyīgègēshǒudōuyǒuyīgèyìmíngde.
 1	每	每	DET	_	_	4	det	_	SpaceAfter=No|Gloss=every|Translit=měi|LTranslit=měi
@@ -4098,6 +4509,7 @@
 11	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 412
+# parallel_id = hk/412
 # text = 唉呀！這個沒有人贊成的！
 # translit = 唉ya!zhègèméiyǒurénzànchéngde!
 1	唉呀	唉呀	INTJ	_	_	5	discourse	_	SpaceAfter=No|Translit=唉ya|LTranslit=唉ya
@@ -4111,6 +4523,7 @@
 9	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 413
+# parallel_id = hk/413
 # text = 因為我這年紀的人，應該在家帶孫子，煮飯。
 # translit = yīnwèiwǒzhèniánjìderén,yīnggāizàijiādàisūnzi,zhǔfàn.
 1	因為	因為	ADV	_	_	11	advmod	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
@@ -4130,6 +4543,7 @@
 15	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 414
+# parallel_id = hk/414
 # text = 但我不是那種人，我就是愛出去玩的性格。
 # translit = dànwǒbùshìnàzhǒngrén,wǒjiùshì'àichūqùwándexìnggé.
 1	但	但	CCONJ	_	_	7	cc	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -4151,6 +4565,7 @@
 17	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 415
+# parallel_id = hk/415
 # text = 我很喜歡唱歌。
 # translit = wǒhěnxǐhuanchànggē.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -4160,6 +4575,7 @@
 5	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 416
+# parallel_id = hk/416
 # text = 起初是來唱歌的，漸漸就變成工作。
 # translit = qǐchūshìláichànggēde,jiànjiànjiùbiànchénggōngzuò.
 1	起初	起初	NOUN	_	_	2	obl:tmod	_	SpaceAfter=No|Translit=qǐchū|LTranslit=qǐchū
@@ -4175,6 +4591,7 @@
 11	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 417
+# parallel_id = hk/417
 # text = 上一手退休便讓給我，我就接手啦。
 # translit = shàngyīshǒutuìxiūbiànrànggěiwǒ,wǒjiùjiēshǒula.
 1	上	上	DET	_	_	3	det	_	SpaceAfter=No|Translit=shàng|LTranslit=shàng
@@ -4193,6 +4610,7 @@
 14	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 418
+# parallel_id = hk/418
 # text = 唱歌就是可以抒發開心與不快樂的。
 # translit = chànggējiùshìkěyǐ抒fākāixīnyǔbùkuàilède.
 1	唱歌	唱歌	VERB	_	_	3	nsubj	_	SpaceAfter=No|Translit=chànggē|LTranslit=chànggē
@@ -4208,6 +4626,7 @@
 11	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 419
+# parallel_id = hk/419
 # text = 要我幫忙嗎？
 # translit = yàowǒbāngmángma?
 1	要	要	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yào|LTranslit=yào|Cxn=Interrogative-Polar-Direct|CxnElt=1:Interrogative-Polar-Direct.Clause
@@ -4217,6 +4636,7 @@
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 420
+# parallel_id = hk/420
 # text = 弄到哪裏去了？
 # translit = nòngdàonǎ裏qùle?
 1	弄	弄	VERB	_	_	0	root	_	SpaceAfter=No|Translit=nòng|LTranslit=nòng
@@ -4227,6 +4647,7 @@
 6	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 421
+# parallel_id = hk/421
 # text = 可以怎樣稱呼我？我只知道整條街都稱我「大家姐」，因為我最大，年紀最大。
 # translit = kěyǐzěnyàngchēnghūwǒ?wǒzhǐzhīdàozhěngtiáojiēdōuchēngwǒ‘dàjiājie’,yīnwèiwǒzuìdà,niánjìzuìdà.
 1	可以	可以	AUX	_	_	3	aux	_	SpaceAfter=No|Translit=kěyǐ|LTranslit=kěyǐ
@@ -4258,6 +4679,7 @@
 27	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 422
+# parallel_id = hk/422
 # text = 我姓湯，但整條街沒有人知道我姓湯，沒有人知道我叫什麼名字。
 # translit = wǒxìngtāng,dànzhěngtiáojiēméiyǒurénzhīdàowǒxìngtāng,méiyǒurénzhīdàowǒjiàoshénmemíngzì.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -4285,6 +4707,7 @@
 23	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 423
+# parallel_id = hk/423
 # text = 幫別人打工幾年了。
 # translit = bāngbiéréndǎgōngjǐniánle.
 1	幫	幫	VERB	_	_	0	root	_	SpaceAfter=No|Translit=bāng|LTranslit=bāng
@@ -4296,6 +4719,7 @@
 7	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 424
+# parallel_id = hk/424
 # text = 後來老闆解僱我，我很感謝他解僱我呢！
 # translit = hòuláilǎo闆jiěgùwǒ,wǒhěngǎnxiètājiěgùwǒne!
 1	後來	後來	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=hòulái|LTranslit=hòulái
@@ -4313,6 +4737,7 @@
 13	！	！	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 425
+# parallel_id = hk/425
 # text = 否則我便不能自己開這個檔口。
 # translit = fǒuzéwǒbiànbùnéngzìjǐkāizhègèdàngkǒu.
 1	否則	否則	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=fǒuzé|LTranslit=fǒuzé
@@ -4328,6 +4753,7 @@
 11	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 426
+# parallel_id = hk/426
 # text = 他解僱我以後，剛好這邊的老闆很忙，做不來，打理不了。
 # translit = tājiěgùwǒyǐhòu,gānghǎozhèbiāndelǎo闆hěnmáng,zuòbùlái,dǎlǐbùle.
 1	他	他	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -4352,6 +4778,7 @@
 20	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 427
+# parallel_id = hk/427
 # text = 我看上了，就跟他說不如把桌子椅子讓給我，才做了一年半呢。
 # translit = wǒkànshàngle,jiùgēntāshuōbùrúbǎzhuōziyǐzirànggěiwǒ,cáizuòleyīniánbànne.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -4380,6 +4807,7 @@
 24	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 428
+# parallel_id = hk/428
 # text = 我告訴你們年輕的啊，我是過來人。
 # translit = wǒgàosunǐmenniánqīngde'a,wǒshìguòláirén.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -4395,6 +4823,7 @@
 11	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 429
+# parallel_id = hk/429
 # text = 總要幫別人打工的，打過工有經驗了，自己就能做好。
 # translit = zǒngyàobāngbiéréndǎgōngde,dǎguògōngyǒujīngyànle,zìjǐjiùnéngzuòhǎo.
 1	總	總	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=zǒng|LTranslit=zǒng
@@ -4419,12 +4848,14 @@
 20	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 430
+# parallel_id = hk/430
 # text = 天生我材必有用。
 # translit = tiānshēngwǒcáibìyǒuyòng.
 1	天生我材必有用	天生我材必有用	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tiānshēngwǒcáibìyǒuyòng|LTranslit=tiānshēngwǒcáibìyǒuyòng
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 431
+# parallel_id = hk/431
 # text = 多讀書就自然能有用，對嗎？
 # translit = duōdúshūjiùzìránnéngyǒuyòng,duìma?
 1	多	多	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=duō|LTranslit=duō
@@ -4439,6 +4870,7 @@
 10	？	？	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 432
+# parallel_id = hk/432
 # text = 我都是這樣教我女兒的。
 # translit = wǒdōushìzhèyàngjiàowǒnǚrde.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -4452,6 +4884,7 @@
 9	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 433
+# parallel_id = hk/433
 # text = 我只有一個女，沒兒子。
 # translit = wǒzhǐyǒuyīgènǚ,méirzi.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -4466,12 +4899,14 @@
 10	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 434
+# parallel_id = hk/434
 # text = 天生我材必有用。
 # translit = tiānshēngwǒcáibìyǒuyòng.
 1	天生我材必有用	天生我材必有用	VERB	_	_	0	root	_	SpaceAfter=No|Translit=tiānshēngwǒcáibìyǒuyòng|LTranslit=tiānshēngwǒcáibìyǒuyòng
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 435
+# parallel_id = hk/435
 # text = 不用唱得很好聽、很動聽。
 # translit = bùyòngchàngdehěnhǎotīng,hěndòngtīng.
 1	不用	用	AUX	_	Polarity=Neg	2	aux	_	SpaceAfter=No|Translit=bùyòng|LTranslit=yòng
@@ -4485,6 +4920,7 @@
 9	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 436
+# parallel_id = hk/436
 # text = 全都是自發性的，可以抒發自己。
 # translit = quándōushìzìfāxìngde,kěyǐ抒fāzìjǐ.
 1	全	全	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=quán|LTranslit=quán
@@ -4499,6 +4935,7 @@
 10	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 437
+# parallel_id = hk/437
 # text = 比如說《男兒當自強》，多雄壯！
 # translit = bǐrúshuō«nánrdāngzìqiáng»,duōxióngzhuàng!
 1	比如說	比如說	ADP	_	_	3	case	_	SpaceAfter=No|Translit=bǐrúshuō|LTranslit=bǐrúshuō
@@ -4511,6 +4948,7 @@
 8	！	！	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 438
+# parallel_id = hk/438
 # text = 即使音調不對，也可以發洩一下。
 # translit = jíshǐyīndiàobùduì,yěkěyǐfā洩yīxià.
 1	即使	即使	SCONJ	_	_	4	mark	_	SpaceAfter=No|Translit=jíshǐ|LTranslit=jíshǐ
@@ -4525,6 +4963,7 @@
 10	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 439
+# parallel_id = hk/439
 # text = 所以歌檔就是這樣形成，讓勞動者、勞動階級、旅客、西人，來到捧場。
 # translit = suǒyǐgēdàngjiùshìzhèyàngxíngchéng,ràngláodòngzhě,láodòngjiējí,lǚkè,xirén,láidàopěngchǎng.
 1	所以	所以	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=suǒyǐ|LTranslit=suǒyǐ
@@ -4550,6 +4989,7 @@
 21	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 440
+# parallel_id = hk/440
 # text = 以前這檔是彈琴的，我卻不學他們，要創新！
 # translit = yǐqiánzhèdàngshìdànqínde,wǒquèbùxuétāmen,yàochuàngxīn!
 1	以前	以前	NOUN	_	_	5	obl:tmod	_	SpaceAfter=No|Translit=yǐqián|LTranslit=yǐqián
@@ -4570,6 +5010,7 @@
 16	！	！	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 441
+# parallel_id = hk/441
 # text = 我要弄卡拉OK，琴師也不用。
 # translit = wǒyàonòngkǎlāOK,qínshīyěbùyòng.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -4583,6 +5024,7 @@
 9	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 442
+# parallel_id = hk/442
 # text = 像電源，我不用別人的，自己預備發電機。
 # translit = xiàngdiànyuán,wǒbùyòngbiérénde,zìjǐyùbèifādiànjī.
 1	像	像	ADP	_	_	2	case	_	SpaceAfter=No|Translit=xiàng|LTranslit=xiàng
@@ -4600,6 +5042,7 @@
 13	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 443
+# parallel_id = hk/443
 # text = 像昨晚因為下雨，電工不供電他們就沒電了！
 # translit = xiàngzuówǎnyīnwèixiàyǔ,diàngōngbùgōngdiàntāmenjiùméidiànle!
 1	像	像	ADV	_	_	13	advmod	_	SpaceAfter=No|Translit=xiàng|LTranslit=xiàng
@@ -4620,6 +5063,7 @@
 16	！	！	PUNCT	_	_	13	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 444
+# parallel_id = hk/444
 # text = 自己帶發電機，不就有電了？
 # translit = zìjǐdàifādiànjī,bùjiùyǒudiànle?
 1	自己	自己	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=zìjǐ|LTranslit=zìjǐ
@@ -4634,6 +5078,7 @@
 10	？	？	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 445
+# parallel_id = hk/445
 # text = 不過我自己一個女人，體力有限，拉不動，找人幫忙。
 # translit = bùguòwǒzìjǐyīgènǚrén,tǐlìyǒuxiàn,lābùdòng,zhǎorénbāngmáng.
 1	不過	不過	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=bùguò|LTranslit=bùguò
@@ -4655,6 +5100,7 @@
 17	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 446
+# parallel_id = hk/446
 # text = 我做這行業，脾氣都變好了！
 # translit = wǒzuòzhèxíngyè,píqìdōubiànhǎole!
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -4670,6 +5116,7 @@
 11	！	！	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 447
+# parallel_id = hk/447
 # text = 以前脾氣火爆都要變得溫柔可愛。
 # translit = yǐqiánpíqìhuǒbàodōuyàobiàndewēnróukě'ài.
 1	以前	以前	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No|Translit=yǐqián|LTranslit=yǐqián
@@ -4684,6 +5131,7 @@
 10	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 448
+# parallel_id = hk/448
 # text = 我對別人好，別人就對我好！
 # translit = wǒduìbiérénhǎo,biérénjiùduìwǒhǎo!
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -4699,6 +5147,7 @@
 11	！	！	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 449
+# parallel_id = hk/449
 # text = 對著客人要嬉皮笑臉，那別人才會幫你的！
 # translit = duìzhekèrényào嬉píxiàoliǎn,nàbiéréncáihuìbāngnǐde!
 1	對	對	VERB	_	_	5	advcl	_	SpaceAfter=No|Translit=duì|LTranslit=duì
@@ -4717,6 +5166,7 @@
 14	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 450
+# parallel_id = hk/450
 # text = 即使很臭的乞丐、醉酒的人我都不會趕他們走。
 # translit = jíshǐhěnchòude乞丐,zuìjiǔderénwǒdōubùhuìgǎntāmenzǒu.
 1	即使	即使	SCONJ	_	_	5	mark	_	SpaceAfter=No|Translit=jíshǐ|LTranslit=jíshǐ
@@ -4738,6 +5188,7 @@
 17	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 451
+# parallel_id = hk/451
 # text = 有人氣就是有財氣，有財氣就是有福氣，有了福氣就有運氣！
 # translit = yǒurénqìjiùshìyǒucáiqì,yǒucáiqìjiùshìyǒufúqì,yǒulefúqìjiùyǒuyùnqì!
 1	有	有	VERB	_	_	4	csubj	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
@@ -4763,6 +5214,7 @@
 21	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 452
+# parallel_id = hk/452
 # text = 家人有說不要開歌檔嗎？
 # translit = jiārényǒushuōbùyàokāigēdàngma?
 1	家人	家人	NOUN	_	_	3	nsubj	_	SpaceAfter=No|Translit=jiārén|LTranslit=jiārén
@@ -4775,6 +5227,7 @@
 8	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 453
+# parallel_id = hk/453
 # text = 唉呀！這個沒有人贊成的！
 # translit = 唉ya!zhègèméiyǒurénzànchéngde!
 1	唉呀	唉呀	INTJ	_	_	5	discourse	_	SpaceAfter=No|Translit=唉ya|LTranslit=唉ya
@@ -4788,6 +5241,7 @@
 9	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 454
+# parallel_id = hk/454
 # text = 因為我這年紀的人，應該在家帶孫子、煮飯。
 # translit = yīnwèiwǒzhèniánjìderén,yīnggāizàijiādàisūnzi,zhǔfàn.
 1	因為	因為	ADV	_	_	11	advmod	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
@@ -4807,6 +5261,7 @@
 15	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 455
+# parallel_id = hk/455
 # text = 但我不是那種人，我就是愛出去玩的性格，不愛做家務、帶小孩。
 # translit = dànwǒbùshìnàzhǒngrén,wǒjiùshì'àichūqùwándexìnggé,bù'àizuòjiāwu,dàixiǎohái.
 1	但	但	CCONJ	_	_	7	cc	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -4836,6 +5291,7 @@
 25	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 456
+# parallel_id = hk/456
 # text = 所以沒有人贊成，但我就是偏偏不聽別人的話。
 # translit = suǒyǐméiyǒurénzànchéng,dànwǒjiùshìpiānpiānbùtīngbiéréndehuà.
 1	所以	所以	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=suǒyǐ|LTranslit=suǒyǐ
@@ -4856,6 +5312,7 @@
 16	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 457
+# parallel_id = hk/457
 # text = 多數唱張學友、張國榮、Beyond。
 # translit = duōshùchàngzhāngxuéyou,zhāngguóróng,Beyond.
 1	多數	多數	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=duōshù|LTranslit=duōshù
@@ -4868,6 +5325,7 @@
 8	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 458
+# parallel_id = hk/458
 # text = 有些歌他們常常唱的。
 # translit = yǒuxiēgētāmenchángchángchàngde.
 1	有些	有些	DET	_	_	2	det	_	SpaceAfter=No|Translit=yǒuxiē|LTranslit=yǒuxiē
@@ -4879,6 +5337,7 @@
 7	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 459
+# parallel_id = hk/459
 # text = 《讓一切隨風》幾乎天天都有人唱。
 # translit = «ràngyīqièsuífēng»jǐhutiāntiāndōuyǒurénchàng.
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -4893,6 +5352,7 @@
 10	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 460
+# parallel_id = hk/460
 # text = 《分飛燕》呀什麼的。
 # translit = «fēnfēiyàn»yashénmede.
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -4904,6 +5364,7 @@
 7	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 461
+# parallel_id = hk/461
 # text = 不過我這裡不唱粵曲。
 # translit = bùguòwǒzhèlibùchàng粵qū.
 1	不過	不過	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=bùguò|LTranslit=bùguò
@@ -4915,6 +5376,7 @@
 7	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 462
+# parallel_id = hk/462
 # text = 都有人唱新歌！
 # translit = dōuyǒurénchàngxīngē!
 1	都	都	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=dōu|LTranslit=dōu
@@ -4926,6 +5388,7 @@
 7	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 463
+# parallel_id = hk/463
 # text = 唱那個……《從不喜歡孤單一個》都有呢！
 # translit = chàngnàgè……«cóngbùxǐhuangūdānyīgè»dōuyǒune!
 1	唱	唱	VERB	_	_	9	csubj	_	SpaceAfter=No|Translit=chàng|LTranslit=chàng
@@ -4941,6 +5404,7 @@
 11	！	！	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 464
+# parallel_id = hk/464
 # text = 你以前做過什麼呢？
 # translit = nǐyǐqiánzuòguòshénmene?
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -4952,6 +5416,7 @@
 7	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 465
+# parallel_id = hk/465
 # text = 別提了！我在電視台參加比賽，輸了！
 # translit = biétíle!wǒzàidiànshìtáicānjiābǐsài,shūle!
 1	別	別	AUX	_	_	2	aux	_	SpaceAfter=No|Translit=bié|LTranslit=bié
@@ -4969,6 +5434,7 @@
 13	！	！	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 466
+# parallel_id = hk/466
 # text = 八十年代時參賽，入不到圍呢，哈哈！
 # translit = bāshíniándàishícānsài,rùbùdàowéine,hāhā!
 1	八十年代	八十年代	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No|Translit=bāshíniándài|LTranslit=bāshíniándài
@@ -4985,6 +5451,7 @@
 12	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 467
+# parallel_id = hk/467
 # text = 從小就喜歡唱歌？
 # translit = cóngxiǎojiùxǐhuanchànggē?
 1	從小	從小	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=cóngxiǎo|LTranslit=cóngxiǎo
@@ -4994,6 +5461,7 @@
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 468
+# parallel_id = hk/468
 # text = 從小到大都是興趣。
 # translit = cóngxiǎodàodàdōushìxìngqù.
 1	從	從	ADP	_	_	2	case	_	SpaceAfter=No|Translit=cóng|LTranslit=cóng
@@ -5006,6 +5474,7 @@
 8	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 469
+# parallel_id = hk/469
 # text = 但是興趣……發展不了。
 # translit = dànshìxìngqù……fāzhǎnbùle.
 1	但是	但是	CCONJ	_	_	4	cc	_	SpaceAfter=No|Translit=dànshì|LTranslit=dànshì
@@ -5017,6 +5486,7 @@
 7	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 470
+# parallel_id = hk/470
 # text = 二十年前吧，我也曾經在這裡，只有歌廳。
 # translit = 'èrshíniánqiánba,wǒyěcéngjīngzàizhèli,zhǐyǒugētīng.
 1	二十	二十	NUM	_	_	2	nummod	_	SpaceAfter=No|Translit='èrshí|LTranslit='èrshí
@@ -5036,6 +5506,7 @@
 15	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 471
+# parallel_id = hk/471
 # text = 然後就在夜總會唱一SET（四十五分鐘）。
 # translit = ránhòujiùzàiyèzǒnghuìchàngyīSET(sìshíwǔfēnzhōng).
 1	然後	然後	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=ránhòu|LTranslit=ránhòu
@@ -5052,6 +5523,7 @@
 12	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 472
+# parallel_id = hk/472
 # text = 然後我又轉行做經紀了。
 # translit = ránhòuwǒyòuzhuǎnxíngzuòjīngjìle.
 1	然後	然後	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=ránhòu|LTranslit=ránhòu
@@ -5064,6 +5536,7 @@
 8	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 473
+# parallel_id = hk/473
 # text = 以前……消費力高，現在沒有了！
 # translit = yǐqián……xiāofèilìgāo,xiànzàiméiyǒule!
 1	以前	以前	NOUN	_	_	4	obl:tmod	_	SpaceAfter=No|Translit=yǐqián|LTranslit=yǐqián
@@ -5077,6 +5550,7 @@
 9	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 474
+# parallel_id = hk/474
 # text = 以前歌廳就不同了。
 # translit = yǐqiángētīngjiùbùtóngle.
 1	以前	以前	NOUN	_	_	4	obl:tmod	_	SpaceAfter=No|Translit=yǐqián|LTranslit=yǐqián
@@ -5087,6 +5561,7 @@
 6	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 475
+# parallel_id = hk/475
 # text = 那邊會掛著一個箱。
 # translit = nàbiānhuìguàzheyīgèxiāng.
 1	那邊	那邊	NOUN	_	_	3	obl	_	SpaceAfter=No|Translit=nàbiān|LTranslit=nàbiān
@@ -5099,6 +5574,7 @@
 8	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 476
+# parallel_id = hk/476
 # text = 客人會給利是，現在都沒有了。
 # translit = kèrénhuìgěilìshì,xiànzàidōuméiyǒule.
 1	客人	客人	NOUN	_	_	3	nsubj	_	SpaceAfter=No|Translit=kèrén|LTranslit=kèrén
@@ -5113,6 +5589,7 @@
 10	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 477
+# parallel_id = hk/477
 # text = 初初都會覺得好難接受，但無辦法。
 # translit = chūchūdōuhuìjuédehǎonánjiēshòu,dànwúbànfǎ.
 1	初初	初初	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=chūchū|LTranslit=chūchū
@@ -5129,6 +5606,7 @@
 12	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 478
+# parallel_id = hk/478
 # text = 因為我初來到香港，要生存嘛。
 # translit = yīnwèiwǒchūláidàoxiānggǎng,yàoshēngcúnma.
 1	因為	因為	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
@@ -5144,6 +5622,7 @@
 11	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 479
+# parallel_id = hk/479
 # text = 突然覺得香港……哇！租又貴，這又貴，那又貴。
 # translit = tūránjuédexiānggǎng……wa!zūyòuguì,zhèyòuguì,nàyòuguì.
 1	突然	突然	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=tūrán|LTranslit=tūrán
@@ -5166,6 +5645,7 @@
 18	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 480
+# parallel_id = hk/480
 # text = 別人都說：「你一定要融入香港這個潮流，否則就不能生存。」
 # translit = biéréndōushuō:‘nǐyīdìngyàoróngrùxiānggǎngzhègècháoliú,fǒuzéjiùbùnéngshēngcún.’
 1	別人	別人	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=biérén|LTranslit=biérén
@@ -5191,6 +5671,7 @@
 21	」	」	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=’|LTranslit=’
 
 # sent_id = 481
+# parallel_id = hk/481
 # text = 唯有慢慢適應……
 # translit = wéiyǒumànmànshìyīng……
 1	唯有	唯有	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=wéiyǒu|LTranslit=wéiyǒu
@@ -5199,6 +5680,7 @@
 4	……	……	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 482
+# parallel_id = hk/482
 # text = 我藝名叫金燕子，是我在廟街的藝名。
 # translit = wǒyìmíngjiàojīnyànzi,shìwǒzàimiàojiēdeyìmíng.
 1	我	我	PRON	_	_	2	nmod	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -5215,6 +5697,7 @@
 12	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 483
+# parallel_id = hk/483
 # text = 每一個歌手都有一個藝名的。
 # translit = měiyīgègēshǒudōuyǒuyīgèyìmíngde.
 1	每	每	DET	_	_	4	det	_	SpaceAfter=No|Translit=měi|LTranslit=měi
@@ -5230,6 +5713,7 @@
 11	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 484
+# parallel_id = hk/484
 # text = 我在廟街這個歌唱行業已經有十七年。
 # translit = wǒzàimiàojiēzhègègēchàngxíngyèyǐjīngyǒushíqīnián.
 1	我	我	PRON	_	_	9	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -5246,6 +5730,7 @@
 12	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 485
+# parallel_id = hk/485
 # text = 廟街歌壇就是靠客人打賞給歌手。
 # translit = miàojiēgē壇jiùshìkàokèréndǎshǎnggěigēshǒu.
 1	廟街	廟街	PROPN	_	_	2	compound	_	SpaceAfter=No|Translit=miàojiē|LTranslit=miàojiē
@@ -5260,6 +5745,7 @@
 10	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 486
+# parallel_id = hk/486
 # text = 例如我想點唱什麼歌，我付多少錢，一百塊、二百塊甚至三百塊。
 # translit = lìrúwǒxiǎngdiǎnchàngshénmegē,wǒfùduōshǎoqián,yībǎikuài,'èrbǎikuàishénzhìsānbǎikuài.
 1	例如	例如	ADV	_	_	9	advmod	_	SpaceAfter=No|Translit=lìrú|LTranslit=lìrú
@@ -5285,6 +5771,7 @@
 21	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 487
+# parallel_id = hk/487
 # text = 或者想和某個客人唱這首歌，我們有最低消費一百塊。
 # translit = huòzhěxiǎnghémǒugèkèrénchàngzhèshǒugē,wǒmenyǒuzuìdīxiāofèiyībǎikuài.
 1	或者	或者	CCONJ	_	_	7	cc	_	SpaceAfter=No|Translit=huòzhě|LTranslit=huòzhě
@@ -5308,6 +5795,7 @@
 19	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 488
+# parallel_id = hk/488
 # text = 當時我為什麼會入這個行業呢？
 # translit = dāngshíwǒwèishénmehuìrùzhègèxíngyène?
 1	當時	當時	NOUN	_	_	5	obl:tmod	_	SpaceAfter=No|Translit=dāngshí|LTranslit=dāngshí
@@ -5322,6 +5810,7 @@
 10	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 489
+# parallel_id = hk/489
 # text = 因為我在大陸時也是唱歌、做歌手。
 # translit = yīnwèiwǒzàidàlùshíyěshìchànggē,zuògēshǒu.
 1	因為	因為	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
@@ -5338,6 +5827,7 @@
 12	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 490
+# parallel_id = hk/490
 # text = 那我來到香港都希望找到我喜歡的行業工作。
 # translit = nàwǒláidàoxiānggǎngdōuxīwàngzhǎodàowǒxǐhuandexíngyègōngzuò.
 1	那	那	ADV	_	_	7	discourse	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -5357,6 +5847,7 @@
 15	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 491
+# parallel_id = hk/491
 # text = 所以來到香港之後就找朋友、看報紙。
 # translit = suǒyǐláidàoxiānggǎngzhīhòujiùzhǎopéngyou,kànbàozhǐ.
 1	所以	所以	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=suǒyǐ|LTranslit=suǒyǐ
@@ -5373,6 +5864,7 @@
 12	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 492
+# parallel_id = hk/492
 # text = 終於有個朋友介紹我在酒樓夜總會唱歌。
 # translit = zhōngyúyǒugèpéngyoujièshàowǒzàijiǔlóuyèzǒnghuìchànggē.
 1	終於	終於	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zhōngyú|LTranslit=zhōngyú
@@ -5388,6 +5880,7 @@
 11	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 493
+# parallel_id = hk/493
 # text = 在那裡認識了一些唱歌的朋友，就帶我進廟街說：「廟街都有歌唱，但那裡就不一樣，是靠客人打賞。」
 # translit = zàinàlirènshileyīxiēchànggēdepéngyou,jiùdàiwǒjìnmiàojiēshuō:‘miàojiēdōuyǒugēchàng,dànnàlijiùbùyīyàng,shìkàokèréndǎshǎng.’
 1	在	在	ADP	_	_	2	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -5427,6 +5920,7 @@
 35	」	」	PUNCT	_	_	20	punct	_	SpaceAfter=No|Translit=’|LTranslit=’
 
 # sent_id = 494
+# parallel_id = hk/494
 # text = 因為我來了香港之後，香港的朋友都跟我說：「你千萬要明白，你在香港做歌手與在中國大陸做歌手是不同的。」
 # translit = yīnwèiwǒláilexiānggǎngzhīhòu,xiānggǎngdepéngyoudōugēnwǒshuō:‘nǐqiānwànyàomíngbái,nǐzàixiānggǎngzuògēshǒuyǔzàizhōngguódàlùzuògēshǒushìbùtóngde.’
 1	因為	因為	ADV	_	_	14	advmod	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
@@ -5467,6 +5961,7 @@
 36	」	」	PUNCT	_	_	20	punct	_	SpaceAfter=No|Translit=’|LTranslit=’
 
 # sent_id = 495
+# parallel_id = hk/495
 # text = 因為在香港要陪客人飲酒、聊天，要看你能不能接受到。
 # translit = yīnwèizàixiānggǎngyàopéikèrényǐnjiǔ,liáotiān,yàokànnǐnéngbùnéngjiēshòudào.
 1	因為	因為	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
@@ -5490,6 +5985,7 @@
 19	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 496
+# parallel_id = hk/496
 # text = 因為我們一向都是自己一個舞台唱歌，唱完歌就走，不需要與客人打招呼。
 # translit = yīnwèiwǒmenyīxiàngdōushìzìjǐyīgèwǔtáichànggē,chàngwángējiùzǒu,bùxūyàoyǔkèréndǎzhāohū.
 1	因為	因為	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
@@ -5517,6 +6013,7 @@
 23	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 497
+# parallel_id = hk/497
 # text = 那是我們的職業（責）。
 # translit = nàshìwǒmendezhíyè(zé).
 1	那	那	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -5530,6 +6027,7 @@
 9	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 498
+# parallel_id = hk/498
 # text = 我們是拿……
 # translit = wǒmenshìná……
 1	我們	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
@@ -5538,6 +6036,7 @@
 4	……	……	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 499
+# parallel_id = hk/499
 # text = 每一個月都出糧給我們。
 # translit = měiyīgèyuèdōuchūliánggěiwǒmen.
 1	每	每	DET	_	_	4	det	_	SpaceAfter=No|Translit=měi|LTranslit=měi
@@ -5551,6 +6050,7 @@
 9	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 500
+# parallel_id = hk/500
 # text = 那我們就走去別家場館，或「跑場」。
 # translit = nàwǒmenjiùzǒuqùbiéjiāchǎngguǎn,huò‘pǎochǎng’.
 1	那	那	ADV	_	_	4	discourse	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -5569,6 +6069,7 @@
 14	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 501
+# parallel_id = hk/501
 # text = 根本不懂得跟客人相處。
 # translit = gēnběnbùdǒngdegēnkèrénxiāngchù.
 1	根本	根本	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=gēnběn|LTranslit=gēnběn
@@ -5580,6 +6081,7 @@
 7	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 502
+# parallel_id = hk/502
 # text = 其實當時的內心很不開心，覺得好像好委屈自己⋯⋯
 # translit = qíshídāngshídenèixīnhěnbùkāixīn,juédehǎoxiànghǎowěiqūzìjǐ⋯⋯
 1	其實	其實	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=qíshí|LTranslit=qíshí
@@ -5598,6 +6100,7 @@
 14	⋯⋯	⋯⋯	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=⋯⋯|LTranslit=⋯⋯
 
 # sent_id = 503
+# parallel_id = hk/503
 # text = 接著，漸漸認識了客人，那些客人都當我是朋友。
 # translit = jiēzhe,jiànjiànrènshilekèrén,nàxiēkèréndōudāngwǒshìpéngyou.
 1	接著	接著	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=jiēzhe|LTranslit=jiēzhe
@@ -5617,6 +6120,7 @@
 15	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 504
+# parallel_id = hk/504
 # text = 我們一起去飲茶、一起食飯。
 # translit = wǒmenyīqǐqùyǐnchá,yīqǐshífàn.
 1	我們	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
@@ -5629,6 +6133,7 @@
 8	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 505
+# parallel_id = hk/505
 # text = 甚至我請他們飲茶、食飯。
 # translit = shénzhìwǒqǐngtāmenyǐnchá,shífàn.
 1	甚至	甚至	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=shénzhì|LTranslit=shénzhì
@@ -5641,6 +6146,7 @@
 8	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 506
+# parallel_id = hk/506
 # text = 那他們回來就聽我唱歌、打賞給我。
 # translit = nàtāmenhuíláijiùtīngwǒchànggē,dǎshǎnggěiwǒ.
 1	那	那	ADV	_	_	4	discourse	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -5657,6 +6163,7 @@
 12	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 507
+# parallel_id = hk/507
 # text = 我們是退了休才來。
 # translit = wǒmenshìtuìlexiūcáilái.
 1	我們	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
@@ -5669,6 +6176,7 @@
 8	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 508
+# parallel_id = hk/508
 # text = 太悶，在家就阿彌陀佛對住四塊牆！
 # translit = tàimèn,zàijiājiù'āmí陀fúduìzhùsìkuàiqiáng!
 1	太	太	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=tài|LTranslit=tài
@@ -5686,6 +6194,7 @@
 13	！	！	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 509
+# parallel_id = hk/509
 # text = 夜總會是聽別人唱，來這裡是實踐自己唱。
 # translit = yèzǒnghuìshìtīngbiérénchàng,láizhèlishìshíjiànzìjǐchàng.
 1	夜總會	夜總會	NOUN	_	_	2	obl	_	SpaceAfter=No|Translit=yèzǒnghuì|LTranslit=yèzǒnghuì
@@ -5703,6 +6212,7 @@
 13	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 510
+# parallel_id = hk/510
 # text = 感覺不一樣。
 # translit = gǎnjuébùyīyàng.
 1	感覺	感覺	NOUN	_	_	3	nsubj	_	SpaceAfter=No|Translit=gǎnjué|LTranslit=gǎnjué
@@ -5711,6 +6221,7 @@
 4	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 511
+# parallel_id = hk/511
 # text = 是歡樂。
 # translit = shìhuanlè.
 1	是	是	AUX	_	_	2	cop	_	SpaceAfter=No|Translit=shì|LTranslit=shì
@@ -5718,6 +6229,7 @@
 3	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 512
+# parallel_id = hk/512
 # text = 因為我們退休之年，和子女有什麼好談呢？
 # translit = yīnwèiwǒmentuìxiūzhīnián,hézinǚyǒushénmehǎotánne?
 1	因為	因為	ADV	_	_	9	advmod	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
@@ -5736,6 +6248,7 @@
 14	？	？	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 513
+# parallel_id = hk/513
 # text = 你回去自己想想，你和自己的老豆老母有什麼好談？
 # translit = nǐhuíqùzìjǐxiǎngxiǎng,nǐhézìjǐdelǎodòulǎomǔyǒushénmehǎotán?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -5756,6 +6269,7 @@
 16	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 514
+# parallel_id = hk/514
 # text = 談兩句就吵架了，對嗎？
 # translit = tánliǎngjùjiùchǎojiàle,duìma?
 1	談	談	VERB	_	_	5	advcl	_	SpaceAfter=No|Translit=tán|LTranslit=tán
@@ -5770,6 +6284,7 @@
 10	？	？	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 515
+# parallel_id = hk/515
 # text = 出面這裡認識很多朋友，「聽下歌」，「開下心」。
 # translit = chūmiànzhèlirènshihěnduōpéngyou,‘tīngxiàgē’,‘kāixiàxīn’.
 1	出面	出面	NOUN	_	_	3	obl	_	SpaceAfter=No|Translit=chūmiàn|LTranslit=chūmiàn
@@ -5792,6 +6307,7 @@
 18	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 516
+# parallel_id = hk/516
 # text = 累了就回家洗澡「找周公」，幾爽。
 # translit = lèilejiùhuíjiāxǐzǎo‘zhǎozhōugōng’,jǐshuǎng.
 1	累	累	VERB	_	_	4	advcl	_	SpaceAfter=No|Translit=lèi|LTranslit=lèi
@@ -5810,6 +6326,7 @@
 14	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 517
+# parallel_id = hk/517
 # text = 沒苛求。
 # translit = méi苛qiú.
 1	沒	沒	VERB	_	_	0	root	_	SpaceAfter=No|Translit=méi|LTranslit=méi
@@ -5817,6 +6334,7 @@
 3	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 518
+# parallel_id = hk/518
 # text = 你剛說夜總會那年代的廟街跟現在有分別嗎？
 # translit = nǐgāngshuōyèzǒnghuìnàniándàidemiàojiēgēnxiànzàiyǒufēnbiéma?
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -5835,6 +6353,7 @@
 14	？	？	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 519
+# parallel_id = hk/519
 # text = 一樣，一樣……不大分別，只是以前沒有這三檔，現在有了。
 # translit = yīyàng,yīyàng……bùdàfēnbié,zhǐshìyǐqiánméiyǒuzhèsāndàng,xiànzàiyǒule.
 1	一樣	一樣	ADJ	_	_	0	root	_	SpaceAfter=No|Translit=yīyàng|LTranslit=yīyàng
@@ -5859,6 +6378,7 @@
 20	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 520
+# parallel_id = hk/520
 # text = 一、二、三，這三檔⋯⋯
 # translit = yī,'èr,sān,zhèsāndàng⋯⋯
 1	一	一	NUM	_	_	0	root	_	SpaceAfter=No|Translit=yī|LTranslit=yī
@@ -5873,6 +6393,7 @@
 10	⋯⋯	⋯⋯	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=⋯⋯|LTranslit=⋯⋯
 
 # sent_id = 521
+# parallel_id = hk/521
 # text = 我很喜歡唱歌，起初是來唱歌的，漸漸就變成工作。
 # translit = wǒhěnxǐhuanchànggē,qǐchūshìláichànggēde,jiànjiànjiùbiànchénggōngzuò.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -5893,6 +6414,7 @@
 16	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 522
+# parallel_id = hk/522
 # text = 上一手退休便讓給我，我就接手了。
 # translit = shàngyīshǒutuìxiūbiànrànggěiwǒ,wǒjiùjiēshǒule.
 1	上	上	DET	_	_	3	det	_	SpaceAfter=No|Translit=shàng|LTranslit=shàng
@@ -5911,6 +6433,7 @@
 14	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 523
+# parallel_id = hk/523
 # text = 我叫李紅，人人叫我紅姐。
 # translit = wǒjiàolihóng,rénrénjiàowǒhóngjie.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -5924,6 +6447,7 @@
 9	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 524
+# parallel_id = hk/524
 # text = 這條街早上是讓人行的。
 # translit = zhètiáojiēzǎoshàngshìràngrénxíngde.
 1	這	這	DET	_	_	3	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -5938,6 +6462,7 @@
 10	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 525
+# parallel_id = hk/525
 # text = 晚上因為旁邊是政府合署已經關門，沒什麼人使用，很多人在這裡開檔。
 # translit = wǎnshàngyīnwèipángbiānshìzhèngfǔhéshǔyǐjīngguānmén,méishénmerénshǐyòng,hěnduōrénzàizhèlikāidàng.
 1	晚上	晚上	NOUN	_	_	18	obl:tmod	_	SpaceAfter=No|Translit=wǎnshàng|LTranslit=wǎnshàng
@@ -5962,6 +6487,7 @@
 20	。	。	PUNCT	_	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 526
+# parallel_id = hk/526
 # text = 每晚由七點半，到十一點半。
 # translit = měiwǎnyóuqīdiǎnbàn,dàoshíyīdiǎnbàn.
 1	每	每	DET	_	_	2	det	_	SpaceAfter=No|Translit=měi|LTranslit=měi
@@ -5974,6 +6500,7 @@
 8	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 527
+# parallel_id = hk/527
 # text = 都有三十年了。
 # translit = dōuyǒusānshíniánle.
 1	都	都	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=dōu|LTranslit=dōu
@@ -5984,6 +6511,7 @@
 6	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 528
+# parallel_id = hk/528
 # text = 三十年來……又沒有什麼特別經驗，經驗算上讚比罵多。
 # translit = sānshíniánlái……yòuméiyǒushénmetèbiéjīngyàn,jīngyànsuànshàng讚bǐmàduō.
 1	三十	三十	NUM	_	_	2	nummod	_	SpaceAfter=No|Translit=sānshí|LTranslit=sānshí
@@ -6006,6 +6534,7 @@
 18	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 529
+# parallel_id = hk/529
 # text = 有些人移民去外國後，回來都說：「紅姐，你千萬不要結束這個檔啊！這裡是廟街的文化！」
 # translit = yǒuxiērényímínqùwàiguóhòu,huíláidōushuō:‘hóngjie,nǐqiānwànbùyàojiéshùzhègèdàng'a!zhèlishìmiàojiēdewénhuà!’
 1	有些	有些	DET	_	_	2	det	_	SpaceAfter=No|Translit=yǒuxiē|LTranslit=yǒuxiē
@@ -6040,6 +6569,7 @@
 30	」	」	PUNCT	_	_	18	punct	_	SpaceAfter=No|Translit=’|LTranslit=’
 
 # sent_id = 530
+# parallel_id = hk/530
 # text = 他不想廟街失去這樣的特色檔口！
 # translit = tābùxiǎngmiàojiēshīqùzhèyàngdetèsèdàngkǒu!
 1	他	他	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -6054,6 +6584,7 @@
 10	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 531
+# parallel_id = hk/531
 # text = 老一輩差不多都老死了。
 # translit = lǎoyībèichàbùduōdōulǎosǐle.
 1	老	老	ADJ	_	_	3	amod	_	SpaceAfter=No|Translit=lǎo|LTranslit=lǎo
@@ -6066,6 +6597,7 @@
 8	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 532
+# parallel_id = hk/532
 # text = 以前不是這樣的，欄杆那邊圍滿人。
 # translit = yǐqiánbùshìzhèyàngde,lángānnàbiānwéimǎnrén.
 1	以前	以前	NOUN	_	_	4	obl:tmod	_	SpaceAfter=No|Translit=yǐqián|LTranslit=yǐqián
@@ -6082,6 +6614,7 @@
 12	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 533
+# parallel_id = hk/533
 # text = 那時候七十、八十年代，用五百元鈔票摺成紙飛機飛過來的，很樂意消費！
 # translit = nàshíhouqīshí,bāshíniándài,yòngwǔbǎiyuánchāopiào摺chéngzhǐfēijīfēiguòláide,hěnlèyìxiāofèi!
 1	那	那	DET	_	_	2	det	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -6107,6 +6640,7 @@
 21	！	！	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 534
+# parallel_id = hk/534
 # text = 不像現在二十塊、二十塊這樣，真的很闊綽。
 # translit = bùxiàngxiànzài'èrshíkuài,'èrshíkuàizhèyàng,zhēndehěnkuò綽.
 1	不	不	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -6125,6 +6659,7 @@
 14	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 535
+# parallel_id = hk/535
 # text = 他們都是水上人家，做躉船、運輸等。
 # translit = tāmendōushìshuǐshàngrénjiā,zuò躉chuán,yùnshūděng.
 1	他們	他	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=tāmen|LTranslit=tā
@@ -6140,6 +6675,7 @@
 11	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 536
+# parallel_id = hk/536
 # text = 那時候黃、賭、毒百花齊放，最能賺錢的年代。
 # translit = nàshíhouhuáng,dǔ,dúbǎihuāqífàng,zuìnéngzhuànqiándeniándài.
 1	那	那	DET	_	_	2	det	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -6159,6 +6695,7 @@
 15	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 537
+# parallel_id = hk/537
 # text = 梅艷芳剛剛參加歌唱新秀，還未有知名度。
 # translit = méiyàn芳gānggāngcānjiāgēchàngxīnxiù,háiwèiyǒuzhīmíngdù.
 1	梅艷芳	梅艷芳	PROPN	_	_	3	nsubj	_	SpaceAfter=No|Translit=méiyàn芳|LTranslit=méiyàn芳
@@ -6174,6 +6711,7 @@
 11	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 538
+# parallel_id = hk/538
 # text = 你想像一下！
 # translit = nǐxiǎngxiàngyīxià!
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -6182,6 +6720,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 539
+# parallel_id = hk/539
 # text = 梅艷芳在這裡唱過，羅文、尹光又在這裡唱過，多少大明星在這裡唱過呀！
 # translit = méiyàn芳zàizhèlichàngguò,luówén,尹guāngyòuzàizhèlichàngguò,duōshǎodàmíngxīngzàizhèlichàngguòya!
 1	梅艷芳	梅艷芳	PROPN	_	_	4	nsubj	_	SpaceAfter=No|Translit=méiyàn芳|LTranslit=méiyàn芳
@@ -6210,6 +6749,7 @@
 24	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 540
+# parallel_id = hk/540
 # text = 現在是怎樣了？結束了嗎？
 # translit = xiànzàishìzěnyàngle?jiéshùlema?
 1	現在	現在	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No|Translit=xiànzài|LTranslit=xiànzài
@@ -6223,6 +6763,7 @@
 9	？	？	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 541
+# parallel_id = hk/541
 # text = 我站在那邊你們還唱呢！
 # translit = wǒzhànzàinàbiānnǐmenháichàngne!
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -6236,6 +6777,7 @@
 9	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 542
+# parallel_id = hk/542
 # text = 你站著我們也沒有唱啊！
 # translit = nǐzhànzhewǒmenyěméiyǒuchàng'a!
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -6249,6 +6791,7 @@
 9	！	！	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 543
+# parallel_id = hk/543
 # text = 我們快要走了，現在正下雨嘛。
 # translit = wǒmenkuàiyàozǒule,xiànzàizhèngxiàyǔma.
 1	我們	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
@@ -6265,6 +6808,7 @@
 12	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 544
+# parallel_id = hk/544
 # text = 人不留人，雨留人。
 # translit = rénbùliúrén,yǔliúrén.
 1	人	人	NOUN	_	_	3	nsubj	_	SpaceAfter=No|Translit=rén|LTranslit=rén
@@ -6278,6 +6822,7 @@
 9	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 545
+# parallel_id = hk/545
 # text = 無辦法啊。
 # translit = wúbànfǎ'a.
 1	無	無	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wú|LTranslit=wú
@@ -6286,6 +6831,7 @@
 4	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 546
+# parallel_id = hk/546
 # text = 因為有時候會有人投訴，說有噪音，所以我們十一點就要收檔。
 # translit = yīnwèiyǒushíhouhuìyǒuréntóusu,shuōyǒuzàoyīn,suǒyǐwǒmenshíyīdiǎnjiùyàoshōudàng.
 1	因為	因為	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
@@ -6308,6 +6854,7 @@
 18	。	。	PUNCT	_	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 547
+# parallel_id = hk/547
 # text = 有時候延遲十五分鐘。
 # translit = yǒushíhouyánchíshíwǔfēnzhōng.
 1	有時候	有時候	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=yǒushíhou|LTranslit=yǒushíhou
@@ -6317,6 +6864,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 548
+# parallel_id = hk/548
 # text = 家裡的是這個嗎……
 # translit = jiālideshìzhègèma……
 1	家	家	NOUN	_	_	6	nsubj	_	SpaceAfter=No|Gloss=home|Translit=jiā|LTranslit=jiā
@@ -6329,6 +6877,7 @@
 8	……	……	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 549
+# parallel_id = hk/549
 # text = 喂，阿Ｂ呀！
 # translit = wèi,'āBya!
 1	喂	喂	INTJ	_	_	3	discourse	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
@@ -6338,6 +6887,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 550
+# parallel_id = hk/550
 # text = 你陪我去北極看北極星丫……
 # translit = nǐpéiwǒqùběijíkànběijíxīngyā……
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -6351,6 +6901,7 @@
 9	……	……	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 551
+# parallel_id = hk/551
 # text = 北極光丫……
 # translit = běijíguāngyā……
 1	北極光	北極光	NOUN	_	_	0	root	_	SpaceAfter=No|Translit=běijíguāng|LTranslit=běijíguāng
@@ -6358,6 +6909,7 @@
 3	……	……	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 552
+# parallel_id = hk/552
 # text = 很正點，坐郵輪的！
 # translit = hěnzhèngdiǎn,zuòyóulúnde!
 1	很	很	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=hěn|LTranslit=hěn
@@ -6369,6 +6921,7 @@
 7	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 553
+# parallel_id = hk/553
 # text = 你媽咪沒時間呀。
 # translit = nǐmā咪méishíjiānya.
 1	你	你	PRON	_	_	2	nmod	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -6379,6 +6932,7 @@
 6	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 554
+# parallel_id = hk/554
 # text = 問了你媽啦！
 # translit = wènlenǐmāla!
 1	問	問	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wèn|LTranslit=wèn
@@ -6389,6 +6943,7 @@
 6	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 555
+# parallel_id = hk/555
 # text = 是的！
 # translit = shìde!
 1	是	是	AUX	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
@@ -6396,6 +6951,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 556
+# parallel_id = hk/556
 # text = 你為什麼沒空陪我呢？
 # translit = nǐwèishénmeméikōngpéiwǒne?
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -6407,6 +6963,7 @@
 7	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 557
+# parallel_id = hk/557
 # text = 你放暑假的，不用上學的！
 # translit = nǐfàngshǔjiǎde,bùyòngshàngxuéde!
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -6420,6 +6977,7 @@
 9	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 558
+# parallel_id = hk/558
 # text = 是的……！
 # translit = shìde……!
 1	是	是	AUX	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
@@ -6428,6 +6986,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 559
+# parallel_id = hk/559
 # text = 四萬多塊一個人的。
 # translit = sìwànduōkuàiyīgèrénde.
 1	四萬多	四萬多	NUM	_	_	2	nummod	_	SpaceAfter=No|Translit=sìwànduō|LTranslit=sìwànduō
@@ -6439,6 +6998,7 @@
 7	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 560
+# parallel_id = hk/560
 # text = 我不用你付呀。
 # translit = wǒbùyòngnǐfùya.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -6449,6 +7009,7 @@
 6	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 561
+# parallel_id = hk/561
 # text = 我請你去呀！
 # translit = wǒqǐngnǐqùya!
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -6459,6 +7020,7 @@
 6	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 562
+# parallel_id = hk/562
 # text = 你陪我啦！
 # translit = nǐpéiwǒla!
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -6468,6 +7030,7 @@
 5	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 563
+# parallel_id = hk/563
 # text = 是的，超正點的。
 # translit = shìde,chāozhèngdiǎnde.
 1	是	是	AUX	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
@@ -6479,6 +7042,7 @@
 7	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 564
+# parallel_id = hk/564
 # text = 我們坐郵輪，又可以呢……上一上岸又可以去shopping。
 # translit = wǒmenzuòyóulún,yòukěyǐne……shàngyīshàng'ànyòukěyǐqùshopping.
 1	我們	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
@@ -6498,6 +7062,7 @@
 15	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 565
+# parallel_id = hk/565
 # text = 你的錢我全程都付了。
 # translit = nǐdeqiánwǒquánchéngdōufùle.
 1	你	你	PRON	_	_	3	nmod	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -6512,6 +7077,7 @@
 10	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 566
+# parallel_id = hk/566
 # text = 給你付……船費、旅行費、酒店費。
 # translit = gěinǐfù……chuánfèi,lǚxíngfèi,jiǔdiànfèi.
 1	給	給	ADP	_	_	2	case	_	SpaceAfter=No|Translit=gěi|LTranslit=gěi
@@ -6526,6 +7092,7 @@
 10	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 567
+# parallel_id = hk/567
 # text = 四萬多塊一個人的！
 # translit = sìwànduōkuàiyīgèrénde!
 1	四萬多	四萬多	NUM	_	_	2	nummod	_	SpaceAfter=No|Translit=sìwànduō|LTranslit=sìwànduō
@@ -6537,6 +7104,7 @@
 7	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 568
+# parallel_id = hk/568
 # text = 只是坐郵輪那一筆已經……
 # translit = zhǐshìzuòyóulúnnàyībǐyǐjīng……
 1	只是	只是	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zhǐshì|LTranslit=zhǐshì
@@ -6549,6 +7117,7 @@
 8	……	……	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 569
+# parallel_id = hk/569
 # text = 是的！
 # translit = shìde!
 1	是	是	AUX	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
@@ -6556,6 +7125,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 570
+# parallel_id = hk/570
 # text = 為什麼你沒空呢？
 # translit = wèishénmenǐméikōngne?
 1	為什麼	為什麼	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=wèishénme|LTranslit=wèishénme|CxnElt=3:Interrogative-WHInfo-Direct.WHWord
@@ -6565,6 +7135,7 @@
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 571
+# parallel_id = hk/571
 # text = 是的……！
 # translit = shìde……!
 1	是	是	AUX	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
@@ -6573,6 +7144,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 572
+# parallel_id = hk/572
 # text = 你為什麼沒空？
 # translit = nǐwèishénmeméikōng?
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -6581,6 +7153,7 @@
 4	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 573
+# parallel_id = hk/573
 # text = 阿爸、阿媽……沒空啊。
 # translit = 'ābà,'āmā……méikōng'a.
 1	阿爸	阿爸	NOUN	_	_	5	nsubj	_	SpaceAfter=No|Translit='ābà|LTranslit='ābà
@@ -6592,6 +7165,7 @@
 7	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 574
+# parallel_id = hk/574
 # text = 他們要上班。
 # translit = tāmenyàoshàngbān.
 1	他們	他	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=tāmen|LTranslit=tā
@@ -6600,6 +7174,7 @@
 4	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 575
+# parallel_id = hk/575
 # text = 不然我不用找你了！
 # translit = bùránwǒbùyòngzhǎonǐle!
 1	不然	不然	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=bùrán|LTranslit=bùrán
@@ -6611,6 +7186,7 @@
 7	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 576
+# parallel_id = hk/576
 # text = 是的，你陪我去啦！
 # translit = shìde,nǐpéiwǒqùla!
 1	是	是	AUX	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
@@ -6624,6 +7200,7 @@
 9	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 577
+# parallel_id = hk/577
 # text = 不用你付呀……我請你呀！
 # translit = bùyòngnǐfùya……wǒqǐngnǐya!
 1	不用	用	VERB	_	Polarity=Neg	0	root	_	SpaceAfter=No|Translit=bùyòng|LTranslit=yòng
@@ -6638,6 +7215,7 @@
 10	！	！	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 578
+# parallel_id = hk/578
 # text = 我們去見識一下嘛。
 # translit = wǒmenqùjiànshiyīxiàma.
 1	我們	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
@@ -6648,6 +7226,7 @@
 6	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 579
+# parallel_id = hk/579
 # text = 沒試過嘛。
 # translit = méishìguòma.
 1	沒	沒	PART	_	Polarity=Neg	2	advmod	_	SpaceAfter=No|Translit=méi|LTranslit=méi
@@ -6657,6 +7236,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 580
+# parallel_id = hk/580
 # text = 坐郵輪去看北極星！
 # translit = zuòyóulúnqùkànběijíxīng!
 1	坐	坐	VERB	_	_	3	advcl	_	SpaceAfter=No|Translit=zuò|LTranslit=zuò
@@ -6667,6 +7247,7 @@
 6	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 581
+# parallel_id = hk/581
 # text = 你放暑假的那時候，不用上學的！
 # translit = nǐfàngshǔjiǎdenàshíhou,bùyòngshàngxuéde!
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -6682,6 +7263,7 @@
 11	！	！	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 582
+# parallel_id = hk/582
 # text = 是的……
 # translit = shìde……
 1	是	是	AUX	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
@@ -6689,6 +7271,7 @@
 3	……	……	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 583
+# parallel_id = hk/583
 # text = ＯＫ的！
 # translit = OKde!
 1	ＯＫ	ＯＫ	VERB	_	_	0	root	_	SpaceAfter=No|Translit=OK|LTranslit=OK
@@ -6696,6 +7279,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 584
+# parallel_id = hk/584
 # text = 我請你去！
 # translit = wǒqǐngnǐqù!
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -6705,6 +7289,7 @@
 5	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 585
+# parallel_id = hk/585
 # text = 就這樣說吧！
 # translit = jiùzhèyàngshuōba!
 1	就	就	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=jiù|LTranslit=jiù
@@ -6714,6 +7299,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 586
+# parallel_id = hk/586
 # text = 你放暑假，不用上學的！
 # translit = nǐfàngshǔjiǎ,bùyòngshàngxuéde!
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -6726,6 +7312,7 @@
 8	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 587
+# parallel_id = hk/587
 # text = 是的……！
 # translit = shìde……!
 1	是	是	AUX	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
@@ -6734,6 +7321,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 588
+# parallel_id = hk/588
 # text = 沒問題，我請你呀！
 # translit = méiwèntí,wǒqǐngnǐya!
 1	沒	沒	VERB	_	_	0	root	_	SpaceAfter=No|Translit=méi|LTranslit=méi
@@ -6746,6 +7334,7 @@
 8	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 589
+# parallel_id = hk/589
 # text = 你去啦！
 # translit = nǐqùla!
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -6754,6 +7343,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 590
+# parallel_id = hk/590
 # text = 你只是陪我嘛，沒關係喇。
 # translit = nǐzhǐshìpéiwǒma,méiguānxìlǎ.
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -6768,6 +7358,7 @@
 10	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 591
+# parallel_id = hk/591
 # text = 今天星期二！
 # translit = jīntiānxīngqī'èr!
 1	今天	今天	NOUN	_	_	2	obl:tmod	_	SpaceAfter=No|Translit=jīntiān|LTranslit=jīntiān
@@ -6775,6 +7366,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 592
+# parallel_id = hk/592
 # text = 今天是星期三嗎？
 # translit = jīntiānshìxīngqīsānma?
 1	今天	今天	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No|Translit=jīntiān|LTranslit=jīntiān
@@ -6784,6 +7376,7 @@
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 593
+# parallel_id = hk/593
 # text = 今天星期四！
 # translit = jīntiānxīngqīsì!
 1	今天	今天	NOUN	_	_	2	obl:tmod	_	SpaceAfter=No|Translit=jīntiān|LTranslit=jīntiān
@@ -6791,6 +7384,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 594
+# parallel_id = hk/594
 # text = 金剛郵輪九折！
 # translit = jīngāngyóulúnjiǔzhé!
 1	金剛郵輪	金剛郵輪	PROPN	_	_	3	dislocated	_	SpaceAfter=No|Translit=jīngāngyóulún|LTranslit=jīngāngyóulún
@@ -6799,6 +7393,7 @@
 4	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 595
+# parallel_id = hk/595
 # text = 現在出發！
 # translit = xiànzàichūfā!
 1	現在	現在	NOUN	_	_	2	obl:tmod	_	SpaceAfter=No|Translit=xiànzài|LTranslit=xiànzài
@@ -6806,6 +7401,7 @@
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 596
+# parallel_id = hk/596
 # text = 昨晚呢，我下班回到家裡。
 # translit = zuówǎnne,wǒxiàbānhuídàojiāli.
 1	昨晚	昨晚	NOUN	_	_	5	obl:tmod	_	SpaceAfter=No|Translit=zuówǎn|LTranslit=zuówǎn
@@ -6820,6 +7416,7 @@
 10	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 597
+# parallel_id = hk/597
 # text = 然之後，我兒子問我：「你明天去旅行嗎？」
 # translit = ránzhīhòu,wǒrziwènwǒ:‘nǐmíngtiānqùlǚxíngma?’
 1	然之後	然之後	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=ránzhīhòu|LTranslit=ránzhīhòu
@@ -6839,6 +7436,7 @@
 15	」	」	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=’|LTranslit=’
 
 # sent_id = 598
+# parallel_id = hk/598
 # text = 我說：「是啊！」
 # translit = wǒshuō:‘shì'a!’
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -6851,6 +7449,7 @@
 8	」	」	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=’|LTranslit=’
 
 # sent_id = 599
+# parallel_id = hk/599
 # text = 「那你甚麼時候回來呀？」
 # translit = ‘nànǐshénmeshíhouhuíláiya?’
 1	「	「	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=‘|LTranslit=‘
@@ -6864,6 +7463,7 @@
 9	」	」	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=’|LTranslit=’
 
 # sent_id = 600
+# parallel_id = hk/600
 # text = 我不知道啊！
 # translit = wǒbùzhīdào'a!
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -6873,6 +7473,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 601
+# parallel_id = hk/601
 # text = 總之我明晚不回家啦
 # translit = zǒngzhīwǒmíngwǎnbùhuíjiāla
 1	總之	總之	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=zǒngzhī|LTranslit=zǒngzhī
@@ -6883,6 +7484,7 @@
 6	啦	啦	PART	_	_	5	discourse:sp	_	SpaceAfter=No|Translit=la|LTranslit=la
 
 # sent_id = 602
+# parallel_id = hk/602
 # text = 他說：「那你甚麼時候會回來？」
 # translit = tāshuō:‘nànǐshénmeshíhouhuìhuílái?’
 1	他	他	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -6899,6 +7501,7 @@
 12	」	」	PUNCT	_	_	10	punct	_	SpaceAfter=No|Translit=’|LTranslit=’
 
 # sent_id = 603
+# parallel_id = hk/603
 # text = 我不知道啊。
 # translit = wǒbùzhīdào'a.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -6908,6 +7511,7 @@
 5	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 604
+# parallel_id = hk/604
 # text = 我明天晚上會……不回來。
 # translit = wǒmíngtiānwǎnshànghuì……bùhuílái.
 1	我	我	PRON	_	_	7	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -6920,6 +7524,7 @@
 8	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 605
+# parallel_id = hk/605
 # text = 接下來甚麼時候回來就不知道了。
 # translit = jiēxiàláishénmeshíhouhuíláijiùbùzhīdàole.
 1	接下來	接下來	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=jiēxiàlái|LTranslit=jiēxiàlái
@@ -6933,6 +7538,7 @@
 9	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 606
+# parallel_id = hk/606
 # text = 總之明晚不回家了。
 # translit = zǒngzhīmíngwǎnbùhuíjiāle.
 1	總之	總之	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=zǒngzhī|LTranslit=zǒngzhī
@@ -6943,6 +7549,7 @@
 6	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 607
+# parallel_id = hk/607
 # text = 有甚麼事？
 # translit = yǒushénmeshì?
 1	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
@@ -6951,6 +7558,7 @@
 4	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 608
+# parallel_id = hk/608
 # text = 為什麼這樣問？
 # translit = wèishénmezhèyàngwèn?
 1	為什麼	為什麼	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=wèishénme|LTranslit=wèishénme|CxnElt=3:Interrogative-WHInfo-Direct.WHWord
@@ -6959,6 +7567,7 @@
 4	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 609
+# parallel_id = hk/609
 # text = 沒甚麼……我掛念你而已……
 # translit = méishénme……wǒguàniànnǐ'éryǐ……
 1	沒	沒	VERB	_	_	0	root	_	SpaceAfter=No|Translit=méi|LTranslit=méi
@@ -6971,6 +7580,7 @@
 8	……	……	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 610
+# parallel_id = hk/610
 # text = 可能會掛念你而已。
 # translit = kěnénghuìguàniànnǐ'éryǐ.
 1	可能	可能	AUX	_	_	3	aux	_	SpaceAfter=No|Translit=kěnéng|LTranslit=kěnéng
@@ -6981,12 +7591,14 @@
 6	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 611
+# parallel_id = hk/611
 # text = 這樣子……
 # translit = zhèyàngzi……
 1	這樣子	這樣子	PRON	_	_	0	root	_	SpaceAfter=No|Translit=zhèyàngzi|LTranslit=zhèyàngzi
 2	……	……	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 612
+# parallel_id = hk/612
 # text = 他整天都爆的！
 # translit = tāzhěngtiāndōubàode!
 1	他	他	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -6997,6 +7609,7 @@
 6	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 613
+# parallel_id = hk/613
 # text = 血壓高吧！
 # translit = xuèyāgāoba!
 1	血壓	血壓	NOUN	_	_	2	nsubj	_	SpaceAfter=No|Translit=xuèyā|LTranslit=xuèyā
@@ -7005,6 +7618,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 614
+# parallel_id = hk/614
 # text = 哎也，是嗎？
 # translit = 'āiyě,shìma?
 1	哎也	哎也	INTJ	_	_	3	discourse:sp	_	SpaceAfter=No|Translit='āiyě|LTranslit='āiyě
@@ -7014,6 +7628,7 @@
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 615
+# parallel_id = hk/615
 # text = 是的，有量血壓嗎？
 # translit = shìde,yǒuliàngxuèyāma?
 1	是	是	AUX	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
@@ -7026,6 +7641,7 @@
 8	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 616
+# parallel_id = hk/616
 # text = 唱得不錯！
 # translit = chàngdebùcuò!
 1	唱	唱	VERB	_	_	0	root	_	SpaceAfter=No|Translit=chàng|LTranslit=chàng
@@ -7034,6 +7650,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 617
+# parallel_id = hk/617
 # text = 是的，不錯！
 # translit = shìde,bùcuò!
 1	是	是	AUX	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
@@ -7043,6 +7660,7 @@
 5	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 618
+# parallel_id = hk/618
 # text = 是騎馬舞啊！
 # translit = shìqímǎwǔ'a!
 1	是	是	AUX	_	_	2	aux	_	SpaceAfter=No|Translit=shì|LTranslit=shì
@@ -7051,6 +7669,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 619
+# parallel_id = hk/619
 # text = ……不懂啊……
 # translit = ……bùdǒng'a……
 1	……	……	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
@@ -7060,6 +7679,7 @@
 5	……	……	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 620
+# parallel_id = hk/620
 # text = 太新的歌。
 # translit = tàixīndegē.
 1	太	太	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=tài|LTranslit=tài
@@ -7069,6 +7689,7 @@
 5	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 621
+# parallel_id = hk/621
 # text = 我不是這年代。
 # translit = wǒbùshìzhèniándài.
 1	我	我	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -7079,6 +7700,7 @@
 6	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 622
+# parallel_id = hk/622
 # text = 我不是這年代！
 # translit = wǒbùshìzhèniándài!
 1	我	我	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -7089,6 +7711,7 @@
 6	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 623
+# parallel_id = hk/623
 # text = 誰玩樂器？
 # translit = shuíwánlèqì?
 1	誰	誰	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=shuí|LTranslit=shuí|CxnElt=2:Interrogative-WHInfo-Direct.WHWord
@@ -7097,6 +7720,7 @@
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 624
+# parallel_id = hk/624
 # text = 卡啦ＯＫ嗎？
 # translit = kǎlaOKma?
 1	卡啦ＯＫ	卡啦ＯＫ	NOUN	_	_	0	root	_	SpaceAfter=No|Translit=kǎlaOK|LTranslit=kǎlaOK|Cxn=Interrogative-Polar-Direct|CxnElt=1:Interrogative-Polar-Direct.Clause
@@ -7104,6 +7728,7 @@
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 625
+# parallel_id = hk/625
 # text = 玩得開心……
 # translit = wándekāixīn……
 1	玩	玩	VERB	_	_	0	root	_	SpaceAfter=No|Translit=wán|LTranslit=wán
@@ -7112,6 +7737,7 @@
 4	……	……	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 626
+# parallel_id = hk/626
 # text = 繼續玩吧……繼續玩吧！
 # translit = jìxùwánba……jìxùwánba!
 1	繼續	繼續	VERB	_	_	0	root	_	SpaceAfter=No|Translit=jìxù|LTranslit=jìxù
@@ -7124,6 +7750,7 @@
 8	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 627
+# parallel_id = hk/627
 # text = 不如先看一下鄭多變教的蟹蟹瘦身操
 # translit = bùrúxiānkànyīxiàzhèngduōbiànjiàode蟹蟹shòushēncāo
 1	不如	不如	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=bùrú|LTranslit=bùrú
@@ -7136,6 +7763,7 @@
 8	蟹蟹瘦身操	蟹蟹瘦身操	PROPN	_	_	3	obj	_	SpaceAfter=No|Translit=蟹蟹shòushēncāo|LTranslit=蟹蟹shòushēncāo
 
 # sent_id = 628
+# parallel_id = hk/628
 # text = 你要繳付四千二百六十元兩毫四仙。
 # translit = nǐyàojiǎofùsìqiān'èrbǎiliùshíyuánliǎngháosìxian.
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -7150,6 +7778,7 @@
 10	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 629
+# parallel_id = hk/629
 # text = 四四方方那個，小一點的！
 # translit = sìsìfāngfāngnàgè,xiǎoyīdiǎnde!
 1	四四方方	四四方方	ADJ	_	_	3	amod	_	SpaceAfter=No|Translit=sìsìfāngfāng|LTranslit=sìsìfāngfāng
@@ -7162,6 +7791,7 @@
 8	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 630
+# parallel_id = hk/630
 # text = 三十乘三十吧？
 # translit = sānshíchéngsānshíba?
 1	三十	三十	NUM	_	_	2	nummod	_	SpaceAfter=No|Translit=sānshí|LTranslit=sānshí
@@ -7171,6 +7801,7 @@
 5	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 631
+# parallel_id = hk/631
 # text = 是的！
 # translit = shìde!
 1	是	是	AUX	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
@@ -7178,6 +7809,7 @@
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 632
+# parallel_id = hk/632
 # text = 那個呢？
 # translit = nàgène?
 1	那	那	DET	_	_	2	det	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -7186,6 +7818,7 @@
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 633
+# parallel_id = hk/633
 # text = 那個吧！
 # translit = nàgèba!
 1	那	那	DET	_	_	2	det	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -7194,6 +7827,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 634
+# parallel_id = hk/634
 # text = 說了你要量好尺寸。
 # translit = shuōlenǐyàoliànghǎochǐcùn.
 1	說	說	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shuō|LTranslit=shuō
@@ -7206,12 +7840,14 @@
 8	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 635
+# parallel_id = hk/635
 # text = 這樣？
 # translit = zhèyàng?
 1	這樣	這樣	PRON	_	_	0	root	_	SpaceAfter=No|Translit=zhèyàng|LTranslit=zhèyàng|Cxn=Interrogative-Reduced|CxnElt=1:Interrogative-Reduced.Clause
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 636
+# parallel_id = hk/636
 # text = 是的，這個比較好。
 # translit = shìde,zhègèbǐjiàohǎo.
 1	是	是	AUX	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
@@ -7224,6 +7860,7 @@
 8	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 637
+# parallel_id = hk/637
 # text = 不要太靠近電視啊！
 # translit = bùyàotàikàojìndiànshì'a!
 1	不要	要	AUX	_	Polarity=Neg	3	aux	_	SpaceAfter=No|Translit=bùyào|LTranslit=yào
@@ -7234,6 +7871,7 @@
 6	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 638
+# parallel_id = hk/638
 # text = 小心弄破了！
 # translit = xiǎoxīnnòngpòle!
 1	小心	小心	VERB	_	_	2	advcl	_	SpaceAfter=No|Translit=xiǎoxīn|LTranslit=xiǎoxīn
@@ -7243,6 +7881,7 @@
 5	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 639
+# parallel_id = hk/639
 # text = Philip_Wong……又吃這麼多。
 # translit = Philip_Wong……yòuchīzhèmeduō.
 1	Philip_	Philip_	PROPN	_	_	5	nsubj	_	SpaceAfter=No|Translit=Philip_|LTranslit=Philip_
@@ -7255,6 +7894,7 @@
 8	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 640
+# parallel_id = hk/640
 # text = 胖死你呀，吃這麼多！
 # translit = pàngsǐnǐya,chīzhèmeduō!
 1	胖	胖	VERB	_	_	0	root	_	SpaceAfter=No|Translit=pàng|LTranslit=pàng|Cxn=Resultative|CxnElt=1:Resultative.Event
@@ -7268,6 +7908,7 @@
 9	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 641
+# parallel_id = hk/641
 # text = 下一站是天富。
 # translit = xiàyīzhànshìtiānfù.
 1	下	下	DET	_	_	3	det	_	SpaceAfter=No|Translit=xià|LTranslit=xià
@@ -7278,6 +7919,7 @@
 6	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 642
+# parallel_id = hk/642
 # text = 媽、爸：八日七夜吉隆坡＋浮羅交怡之旅來到第四天。
 # translit = mā,bà:bārìqīyèjílóngpō+fúluójiāo怡zhīlǚláidàodìsìtiān.
 1	媽	媽	NOUN	_	_	14	vocative	_	SpaceAfter=No|Translit=mā|LTranslit=mā
@@ -7300,6 +7942,7 @@
 18	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 643
+# parallel_id = hk/643
 # text = 住在這家酒店，真的很正！
 # translit = zhùzàizhèjiājiǔdiàn,zhēndehěnzhèng!
 1	住	住	VERB	_	_	0	root	_	SpaceAfter=No|Translit=zhù|LTranslit=zhù
@@ -7314,6 +7957,7 @@
 10	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 644
+# parallel_id = hk/644
 # text = 一行出去就係泳池，再行出Ｄ就係沙灘！
 # translit = yīxíngchūqùjiùxìyǒngchí,zàixíngchūDjiùxìshātān!
 1	一	一	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=yī|LTranslit=yī
@@ -7333,6 +7977,7 @@
 15	！	！	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 645
+# parallel_id = hk/645
 # text = 又曬黑番黎喇，哈哈！
 # translit = yòu曬hēifānlílǎ,hāhā!
 1	又	又	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=yòu|LTranslit=yòu
@@ -7345,6 +7990,7 @@
 8	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 646
+# parallel_id = hk/646
 # text = 有無想念我呢？
 # translit = yǒuwúxiǎngniànwǒne?
 1	有	有	AUX	_	_	3	aux	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
@@ -7355,6 +8001,7 @@
 6	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 647
+# parallel_id = hk/647
 # text = 很快回來。
 # translit = hěnkuàihuílái.
 1	很	很	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=hěn|LTranslit=hěn
@@ -7363,6 +8010,7 @@
 4	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 648
+# parallel_id = hk/648
 # text = 秋，一四年五月二十二日。
 # translit = qiū,yīsìniánwǔyuè'èrshí'èrrì.
 1	秋	秋	PROPN	_	_	0	root	_	SpaceAfter=No|Translit=qiū|LTranslit=qiū
@@ -7373,6 +8021,7 @@
 6	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 649
+# parallel_id = hk/649
 # text = 喂，明信片啊！
 # translit = wèi,míngxìnpiàn'a!
 1	喂	喂	INTJ	_	_	3	discourse	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
@@ -7382,6 +8031,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=!|LTranslit=!
 
 # sent_id = 650
+# parallel_id = hk/650
 # text = 都已經回來了……
 # translit = dōuyǐjīnghuíláile……
 1	都	都	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=dōu|LTranslit=dōu
@@ -7391,6 +8041,7 @@
 5	……	……	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 651
+# parallel_id = hk/651
 # text = 剛才秘書處已宣布五分鐘後復會。
 # translit = gāngcáimìshūchùyǐxuānbùwǔfēnzhōnghòufùhuì.
 1	剛才	剛才	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=gāngcái|LTranslit=gāngcái
@@ -7404,6 +8055,7 @@
 9	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 652
+# parallel_id = hk/652
 # text = 現在時間已過了五分鐘。
 # translit = xiànzàishíjiānyǐguòlewǔfēnzhōng.
 1	現在	現在	NOUN	_	_	4	obl:tmod	_	SpaceAfter=No|Translit=xiànzài|LTranslit=xiànzài
@@ -7416,6 +8068,7 @@
 8	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 653
+# parallel_id = hk/653
 # text = 我想跟大家說，今天的會議分為兩部分。
 # translit = wǒxiǎnggēndàjiāshuō,jīntiāndehuìyìfēnwèiliǎngbùfēn.
 1	我	我	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -7433,6 +8086,7 @@
 13	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 654
+# parallel_id = hk/654
 # text = 第一部分是剛才大家已完成的宣誓。
 # translit = dìyībùfēnshìgāngcáidàjiāyǐwánchéngdexuānshì.
 1	第一	第一	ADJ	_	_	2	amod	_	SpaceAfter=No|Translit=dìyī|LTranslit=dìyī
@@ -7447,6 +8101,7 @@
 10	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 655
+# parallel_id = hk/655
 # text = 而第二部分是選舉立法會主席。
 # translit = 'érdì'èrbùfēnshìxuǎnjǔlìfǎhuìzhǔxí.
 1	而	而	CCONJ	_	_	4	advmod	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -7459,6 +8114,7 @@
 8	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 656
+# parallel_id = hk/656
 # text = 我知道有同事對主席候選人的國籍問題有些意見。
 # translit = wǒzhīdàoyǒutóngshìduìzhǔxíhouxuǎnréndeguójíwèntíyǒuxiēyìjiàn.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -7477,6 +8133,7 @@
 14	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 657
+# parallel_id = hk/657
 # text = 要求候選人就某些方面作出澄清。
 # translit = yàoqiúhouxuǎnrénjiùmǒuxiēfāngmiànzuòchū澄qīng.
 1	要求	要求	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yàoqiú|LTranslit=yàoqiú
@@ -7489,6 +8146,7 @@
 8	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 658
+# parallel_id = hk/658
 # text = 由於今天的會議並沒有任何程序，容許我們在會議廳內進行澄清、提問、辯論或諮詢等，因此我們不可以在會議廳內進行這些工作。
 # translit = yóuyújīntiāndehuìyìbìngméiyǒurènhéchéngxù,róngxǔwǒmenzàihuìyìtīngnèijìnxíng澄qīng,tíwèn,biànlùnhuò諮xúnděng,yīncǐwǒmenbùkěyǐzàihuìyìtīngnèijìnxíngzhèxiēgōngzuò.
 1	由於	由於	SCONJ	_	_	6	mark	_	SpaceAfter=No|Translit=yóuyú|LTranslit=yóuyú
@@ -7528,6 +8186,7 @@
 35	。	。	PUNCT	_	_	32	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 659
+# parallel_id = hk/659
 # text = 不過，為讓一些關注此事的議員能獲澄清，我建議梁君彥議員稍後到會議廳外，向新聞傳媒交代他的國籍問題。
 # translit = bùguò,wèiràngyīxiēguānzhùcǐshìdeyìyuánnénghuò澄qīng,wǒjiànyìliángjūn彥yìyuánshāohòudàohuìyìtīngwài,xiàngxīnwénchuánméijiāodàitādeguójíwèntí.
 1	不過	不過	ADV	_	_	16	advmod	_	SpaceAfter=No|Translit=bùguò|LTranslit=bùguò
@@ -7564,6 +8223,7 @@
 32	。	。	PUNCT	_	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 660
+# parallel_id = hk/660
 # text = 而關注此事的議員亦可出去聆聽他的闡述，以及可以向他提問。
 # translit = 'érguānzhùcǐshìdeyìyuányìkěchūqù聆tīngtādechǎnshù,yǐjíkěyǐxiàngtātíwèn.
 1	而	而	CCONJ	_	_	9	advmod	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -7588,6 +8248,7 @@
 20	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 661
+# parallel_id = hk/661
 # text = 在會議廳內，根據《議事規則》，我不能容許大家提問或作出任何討論。
 # translit = zàihuìyìtīngnèi,gēnjù«yìshìguīzé»,wǒbùnéngróngxǔdàjiātíwènhuòzuòchūrènhétǎolùn.
 1	在	在	ADP	_	_	2	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -7613,6 +8274,7 @@
 21	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 662
+# parallel_id = hk/662
 # text = 我現在請關注此事的議員到會議廳外，聽取梁君彥議員的交代。
 # translit = wǒxiànzàiqǐngguānzhùcǐshìdeyìyuándàohuìyìtīngwài,tīngqǔliángjūn彥yìyuándejiāodài.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -7635,6 +8297,7 @@
 18	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 663
+# parallel_id = hk/663
 # text = 我預期會議將在下午二時三十分正式恢復。
 # translit = wǒyùqīhuìyìjiāngzàixiàwǔ'èrshísānshífēnzhèngshìhuīfù.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -7652,6 +8315,7 @@
 13	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 664
+# parallel_id = hk/664
 # text = 我的發言到此結束。
 # translit = wǒdefāyándàocǐjiéshù.
 1	我	我	PRON	_	_	3	nmod	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -7662,6 +8326,7 @@
 6	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 665
+# parallel_id = hk/665
 # text = 現在暫停會議。
 # translit = xiànzàizàntínghuìyì.
 1	現在	現在	NOUN	_	_	2	obl:tmod	_	SpaceAfter=No|Translit=xiànzài|LTranslit=xiànzài
@@ -7670,6 +8335,7 @@
 4	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 666
+# parallel_id = hk/666
 # text = 現在是二時三十五分，較我原先宣佈二時三十分恢復會議的時間，遲了五分鐘。
 # translit = xiànzàishì'èrshísānshíwǔfēn,jiàowǒyuánxiānxuān佈'èrshísānshífēnhuīfùhuìyìdeshíjiān,chílewǔfēnzhōng.
 1	現在	現在	NOUN	_	_	2	obl:tmod	_	SpaceAfter=No|Translit=xiànzài|LTranslit=xiànzài
@@ -7699,6 +8365,7 @@
 25	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 667
+# parallel_id = hk/667
 # text = 我不想再延遲。
 # translit = wǒbùxiǎngzàiyánchí.
 1	我	我	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -7709,6 +8376,7 @@
 6	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 668
+# parallel_id = hk/668
 # text = 現在宣佈正式復會。
 # translit = xiànzàixuān佈zhèngshìfùhuì.
 1	現在	現在	NOUN	_	_	2	obl:tmod	_	SpaceAfter=No|Translit=xiànzài|LTranslit=xiànzài
@@ -7718,6 +8386,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 669
+# parallel_id = hk/669
 # text = 會議現已恢復，我希望所有同事返回自己的座位。
 # translit = huìyìxiànyǐhuīfù,wǒxīwàngsuǒyǒutóngshìfǎnhuízìjǐdezuòwèi.
 1	會議	會議	NOUN	_	_	4	nsubj	_	SpaceAfter=No|Translit=huìyì|LTranslit=huìyì
@@ -7736,6 +8405,7 @@
 14	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 670
+# parallel_id = hk/670
 # text = 讓我們今天可以有秩序地進行選舉主席的程式。
 # translit = ràngwǒmenjīntiānkěyǐyǒuzhìxùdejìnxíngxuǎnjǔzhǔxídechéngshì.
 1	讓	讓	VERB	_	_	0	root	_	SpaceAfter=No|Translit=ràng|LTranslit=ràng
@@ -7753,6 +8423,7 @@
 13	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 671
+# parallel_id = hk/671
 # text = 我現在再請所有同事返回自己的座位。
 # translit = wǒxiànzàizàiqǐngsuǒyǒutóngshìfǎnhuízìjǐdezuòwèi.
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -7768,6 +8439,7 @@
 11	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 672
+# parallel_id = hk/672
 # text = 有議員想提出規程問題。
 # translit = yǒuyìyuánxiǎngtíchūguīchéngwèntí.
 1	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
@@ -7779,6 +8451,7 @@
 7	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 673
+# parallel_id = hk/673
 # text = 但請其他同事先行返回座位，讓秘書幫我做一些文書工作。
 # translit = dànqǐngqítātóngshìxiānxíngfǎnhuízuòwèi,ràngmìshūbāngwǒzuòyīxiēwénshūgōngzuò.
 1	但	但	CCONJ	_	_	2	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -7800,6 +8473,7 @@
 17	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 674
+# parallel_id = hk/674
 # text = 否則，沒有秘書幫忙，處理上會比較困難。
 # translit = fǒuzé,méiyǒumìshūbāngmáng,chùlǐshànghuìbǐjiàokùnnán.
 1	否則	否則	ADV	_	_	11	advmod	_	SpaceAfter=No|Translit=fǒuzé|LTranslit=fǒuzé
@@ -7816,6 +8490,7 @@
 12	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 675
+# parallel_id = hk/675
 # text = 我希望其他議員先返回座位，讓我們可以進行會議。
 # translit = wǒxīwàngqítāyìyuánxiānfǎnhuízuòwèi,ràngwǒmenkěyǐjìnxínghuìyì.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -7834,6 +8509,7 @@
 14	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 676
+# parallel_id = hk/676
 # text = 如果大家有任何規程問題，可以提出。
 # translit = rúguǒdàjiāyǒurènhéguīchéngwèntí,kěyǐtíchū.
 1	如果	如果	SCONJ	_	_	3	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -7848,6 +8524,7 @@
 10	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 677
+# parallel_id = hk/677
 # text = 我會給大家時間。
 # translit = wǒhuìgěidàjiāshíjiān.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -7858,6 +8535,7 @@
 6	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 678
+# parallel_id = hk/678
 # text = 主席，我想問秘書處有否處理梁君彥議員的國籍問題？
 # translit = zhǔxí,wǒxiǎngwènmìshūchùyǒufǒuchùlǐliángjūn彥yìyuándeguójíwèntí?
 1	主席	主席	NOUN	_	_	5	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -7877,6 +8555,7 @@
 15	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 679
+# parallel_id = hk/679
 # text = 他剛才……
 # translit = tāgāngcái……
 1	他	他	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -7884,6 +8563,7 @@
 3	……	……	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 680
+# parallel_id = hk/680
 # text = 剛才我說過，有關梁君彥議員的國籍問題不是今天會議的討論範疇。
 # translit = gāngcáiwǒshuōguò,yǒuguānliángjūn彥yìyuándeguójíwèntíbùshìjīntiānhuìyìdetǎolùnfàn疇.
 1	剛才	剛才	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=gāngcái|LTranslit=gāngcái
@@ -7907,6 +8587,7 @@
 19	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 681
+# parallel_id = hk/681
 # text = 好的。
 # translit = hǎode.
 1	好	好	INTJ	_	_	0	root	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
@@ -7914,6 +8595,7 @@
 3	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 682
+# parallel_id = hk/682
 # text = 請先讓我說，可以嗎？
 # translit = qǐngxiānràngwǒshuō,kěyǐma?
 1	請	請	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǐng|LTranslit=qǐng
@@ -7927,6 +8609,7 @@
 9	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 683
+# parallel_id = hk/683
 # text = 我剛才已經說過，為了讓大家進一步瞭解有關梁君彥議員的國籍問題，或要求他澄清，我已作出-特別安排時間，讓梁議員在會議廳外向傳媒作出交代和澄清。
 # translit = wǒgāngcáiyǐjīngshuōguò,wèileràngdàjiājìnyībùliǎojiěyǒuguānliángjūn彥yìyuándeguójíwèntí,huòyàoqiútā澄qīng,wǒyǐzuòchū-tèbié'ānpáishíjiān,ràngliángyìyuánzàihuìyìtīngwàixiàngchuánméizuòchūjiāodàihé澄qīng.
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -7975,6 +8658,7 @@
 44	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 684
+# parallel_id = hk/684
 # text = 如果各位剛才有出席，便應該知道情況如何。
 # translit = rúguǒgèwèigāngcáiyǒuchūxí,biànyīnggāizhīdàoqíngkuàngrúhé.
 1	如果	如果	SCONJ	_	_	5	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -7991,6 +8675,7 @@
 12	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 685
+# parallel_id = hk/685
 # text = 不過，無論當事人如何澄清及解釋，在這個會議上，我不能保證令大家滿意。
 # translit = bùguò,wúlùndāngshìrénrúhé澄qīngjíjiěshì,zàizhègèhuìyìshàng,wǒbùnéngbǎozhènglìngdàjiāmǎnyì.
 1	不過	不過	ADV	_	_	18	advmod	_	SpaceAfter=No|Translit=bùguò|LTranslit=bùguò
@@ -8017,6 +8702,7 @@
 22	。	。	PUNCT	_	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 686
+# parallel_id = hk/686
 # text = 作為會議主持人，我祇能根據會議規則進行程序。
 # translit = zuòwèihuìyìzhǔchírén,wǒ祇nénggēnjùhuìyìguīzéjìnxíngchéngxù.
 1	作為	作為	ADP	_	_	3	case	_	SpaceAfter=No|Translit=zuòwèi|LTranslit=zuòwèi
@@ -8034,6 +8720,7 @@
 13	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 687
+# parallel_id = hk/687
 # text = 如果議員想確保他的問題得到滿意的答覆，可以在其他場合提出。
 # translit = rúguǒyìyuánxiǎngquèbǎotādewèntídedàomǎnyìdedáfù,kěyǐzàiqítāchǎnghétíchū.
 1	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -8056,6 +8743,7 @@
 18	。	。	PUNCT	_	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 688
+# parallel_id = hk/688
 # text = 今天的會議中則沒有辦法處理這個問題。
 # translit = jīntiāndehuìyìzhōngzéméiyǒubànfǎchùlǐzhègèwèntí.
 1	今天	今天	NOUN	_	_	3	nmod	_	SpaceAfter=No|Translit=jīntiān|LTranslit=jīntiān
@@ -8071,6 +8759,7 @@
 11	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 689
+# parallel_id = hk/689
 # text = 我現在想問一問，剛才有哪些議員曾舉手想提出規程問題？
 # translit = wǒxiànzàixiǎngwènyīwèn,gāngcáiyǒunǎxiēyìyuáncéngjǔshǒuxiǎngtíchūguīchéngwèntí?
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -8091,6 +8780,7 @@
 16	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 690
+# parallel_id = hk/690
 # text = 我看不到。
 # translit = wǒkànbùdào.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -8100,6 +8790,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 691
+# parallel_id = hk/691
 # text = 請秘書幫忙把曾舉手表示想提出規程問題的議員名單交給我。
 # translit = qǐngmìshūbāngmángbǎcéngjǔshǒubiǎoshìxiǎngtíchūguīchéngwèntídeyìyuánmíngdānjiāogěiwǒ.
 1	請	請	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǐng|LTranslit=qǐng
@@ -8122,6 +8813,7 @@
 18	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 692
+# parallel_id = hk/692
 # text = 因為我看不到。
 # translit = yīnwèiwǒkànbùdào.
 1	因為	因為	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
@@ -8132,6 +8824,7 @@
 6	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 693
+# parallel_id = hk/693
 # text = 今天我不想跟大家爭論其他問題，因為我沒有權力這樣做。
 # translit = jīntiānwǒbùxiǎnggēndàjiāzhēnglùnqítāwèntí,yīnwèiwǒméiyǒuquánlìzhèyàngzuò.
 1	今天	今天	NOUN	_	_	7	obl:tmod	_	SpaceAfter=No|Translit=jīntiān|LTranslit=jīntiān
@@ -8153,6 +8846,7 @@
 17	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 694
+# parallel_id = hk/694
 # text = 我祇是執行會議規則。
 # translit = wǒ祇shìzhíxínghuìyìguīzé.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -8163,6 +8857,7 @@
 6	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 695
+# parallel_id = hk/695
 # text = 其實我也不是很想主持這會議。
 # translit = qíshíwǒyěbùshìhěnxiǎngzhǔchízhèhuìyì.
 1	其實	其實	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=qíshí|LTranslit=qíshí
@@ -8178,6 +8873,7 @@
 11	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 696
+# parallel_id = hk/696
 # text = 不過，根據《議事規則》附表一第六及七段的規定，由擔任議員時間最長的我來主持會議。
 # translit = bùguò,gēnjù«yìshìguīzé»fùbiǎoyīdìliùjíqīduàndeguīdìng,yóudānrènyìyuánshíjiānzuìzhǎngdewǒláizhǔchíhuìyì.
 1	不過	不過	CCONJ	_	_	25	advmod	_	SpaceAfter=No|Translit=bùguò|LTranslit=bùguò
@@ -8210,6 +8906,7 @@
 28	。	。	PUNCT	_	_	25	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 697
+# parallel_id = hk/697
 # text = 根據會議規則，我現在祇能主持投票的過程。
 # translit = gēnjùhuìyìguīzé,wǒxiànzài祇néngzhǔchítóupiàodeguòchéng.
 1	根據	根據	ADP	_	_	3	case	_	SpaceAfter=No|Translit=gēnjù|LTranslit=gēnjù
@@ -8227,6 +8924,7 @@
 13	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 698
+# parallel_id = hk/698
 # text = 其他事情我無法處理。
 # translit = qítāshìqíngwǒwúfǎchùlǐ.
 1	其他	其他	DET	_	_	2	det	_	SpaceAfter=No|Translit=qítā|LTranslit=qítā
@@ -8237,6 +8935,7 @@
 6	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 699
+# parallel_id = hk/699
 # text = 如果我處理的話，便違反會議規則。
 # translit = rúguǒwǒchùlǐdehuà,biànwéifǎnhuìyìguīzé.
 1	如果	如果	SCONJ	_	_	3	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -8251,6 +8950,7 @@
 10	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 700
+# parallel_id = hk/700
 # text = 是不合法的。
 # translit = shìbùhéfǎde.
 1	是	是	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shì|LTranslit=shì
@@ -8260,6 +8960,7 @@
 5	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 701
+# parallel_id = hk/701
 # text = 大家如果要我表明這個會議究竟是否合法，我祇能夠說，根據會議規則，這個會議是合法的。
 # translit = dàjiārúguǒyàowǒbiǎomíngzhègèhuìyìjiūjìngshìfǒuhéfǎ,wǒ祇nénggòushuō,gēnjùhuìyìguīzé,zhègèhuìyìshìhéfǎde.
 1	大家	大家	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=dàjiā|LTranslit=dàjiā
@@ -8293,6 +8994,7 @@
 29	。	。	PUNCT	_	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 702
+# parallel_id = hk/702
 # text = 議員如果想提出規程問題，我再請大家先返回自己的座位。
 # translit = yìyuánrúguǒxiǎngtíchūguīchéngwèntí,wǒzàiqǐngdàjiāxiānfǎnhuízìjǐdezuòwèi.
 1	議員	議員	NOUN	_	_	4	nsubj	_	SpaceAfter=No|Translit=yìyuán|LTranslit=yìyuán
@@ -8314,6 +9016,7 @@
 17	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 703
+# parallel_id = hk/703
 # text = 我會邀請大家發言。
 # translit = wǒhuìyāoqǐngdàjiāfāyán.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -8324,6 +9027,7 @@
 6	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 704
+# parallel_id = hk/704
 # text = 我們不離開又怎樣呢？
 # translit = wǒmenbùlíkāiyòuzěnyàngne?
 1	我們	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
@@ -8335,6 +9039,7 @@
 7	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 705
+# parallel_id = hk/705
 # text = 如果議員真的不返回座位，也不要緊。
 # translit = rúguǒyìyuánzhēndebùfǎnhuízuòwèi,yěbùyàojǐn.
 1	如果	如果	SCONJ	_	_	5	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -8350,6 +9055,7 @@
 11	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 706
+# parallel_id = hk/706
 # text = 但請不要作出騷擾，以便會議可繼續進行。
 # translit = dànqǐngbùyàozuòchū騷rǎo,yǐbiànhuìyìkějìxùjìnxíng.
 1	但	但	CCONJ	_	_	10	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -8366,6 +9072,7 @@
 12	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 707
+# parallel_id = hk/707
 # text = 根據秘書給我的名單，第一位提出規程問題的議員是毛孟靜議員。
 # translit = gēnjùmìshūgěiwǒdemíngdān,dìyīwèitíchūguīchéngwèntídeyìyuánshìmáo孟jìngyìyuán.
 1	根據	根據	ADP	_	_	6	case	_	SpaceAfter=No|Translit=gēnjù|LTranslit=gēnjù
@@ -8388,6 +9095,7 @@
 18	。	。	PUNCT	_	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 708
+# parallel_id = hk/708
 # text = 根據《議事規則》，今天的規程祇能夠涉及選舉過程。
 # translit = gēnjù«yìshìguīzé»,jīntiāndeguīchéng祇nénggòushèjíxuǎnjǔguòchéng.
 1	根據	根據	ADP	_	_	4	case	_	SpaceAfter=No|Translit=gēnjù|LTranslit=gēnjù
@@ -8407,6 +9115,7 @@
 15	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 709
+# parallel_id = hk/709
 # text = 如果有其他問題，請議員在其他場合提出。
 # translit = rúguǒyǒuqítāwèntí,qǐngyìyuánzàiqítāchǎnghétíchū.
 1	如果	如果	SCONJ	_	_	2	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -8423,6 +9132,7 @@
 12	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 710
+# parallel_id = hk/710
 # text = 現在請毛孟靜議員提問。
 # translit = xiànzàiqǐngmáo孟jìngyìyuántíwèn.
 1	現在	現在	NOUN	_	_	2	obl:tmod	_	SpaceAfter=No|Translit=xiànzài|LTranslit=xiànzài
@@ -8433,6 +9143,7 @@
 6	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 711
+# parallel_id = hk/711
 # text = 感謝主席。
 # translit = gǎnxièzhǔxí.
 1	感謝	感謝	VERB	_	_	0	root	_	SpaceAfter=No|Translit=gǎnxiè|LTranslit=gǎnxiè
@@ -8440,6 +9151,7 @@
 3	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 712
+# parallel_id = hk/712
 # text = 我不是故意要為難你或甚麼。
 # translit = wǒbùshìgùyìyàowèinánnǐhuòshénme.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -8454,6 +9166,7 @@
 10	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 713
+# parallel_id = hk/713
 # text = 還要感謝你試圖安排我們到會議廳外聆聽梁君彥議員的解釋。
 # translit = háiyàogǎnxiènǐshìtú'ānpáiwǒmendàohuìyìtīngwài聆tīngliángjūn彥yìyuándejiěshì.
 1	還	還	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=hái|LTranslit=hái
@@ -8474,6 +9187,7 @@
 16	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 714
+# parallel_id = hk/714
 # text = 我們已聽罷他的解釋。
 # translit = wǒmenyǐtīngbatādejiěshì.
 1	我們	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
@@ -8486,6 +9200,7 @@
 8	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 715
+# parallel_id = hk/715
 # text = 他說第一封信是關乎其國籍或外國居留權的問題。
 # translit = tāshuōdìyīfēngxìnshìguānhuqíguójíhuòwàiguójūliúquándewèntí.
 1	他	他	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -8505,6 +9220,7 @@
 15	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 716
+# parallel_id = hk/716
 # text = 信中表示已enclosed（附上）「放棄國籍」的聲明，
 # translit = xìnzhōngbiǎoshìyǐenclosed(fùshàng)‘fàngqìguójí’deshēngmíng,
 1	信	信	NOUN	_	_	3	nsubj	_	SpaceAfter=No|Translit=xìn|LTranslit=xìn
@@ -8524,6 +9240,7 @@
 15	，	，	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 
 # sent_id = 717
+# parallel_id = hk/717
 # text = 但相關的copy卻並不存在。
 # translit = dànxiāngguāndecopyquèbìngbùcúnzài.
 1	但	但	CCONJ	_	_	7	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -8536,6 +9253,7 @@
 8	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 718
+# parallel_id = hk/718
 # text = 原來那是一封電郵。
 # translit = yuánláinàshìyīfēngdiànyóu.
 1	原來	原來	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=yuánlái|LTranslit=yuánlái
@@ -8547,6 +9265,7 @@
 7	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 719
+# parallel_id = hk/719
 # text = 第二封信才是正本。
 # translit = dì'èrfēngxìncáishìzhèngběn.
 1	第二	第二	ADJ	_	_	3	amod	_	SpaceAfter=No|Translit=dì'èr|LTranslit=dì'èr
@@ -8558,6 +9277,7 @@
 7	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 720
+# parallel_id = hk/720
 # text = 但他暫時仍未收到。
 # translit = dàntāzànshíréngwèishōudào.
 1	但	但	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -8570,6 +9290,7 @@
 8	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 721
+# parallel_id = hk/721
 # text = 我想就此提出規程問題。
 # translit = wǒxiǎngjiùcǐtíchūguīchéngwèntí.
 1	我	我	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -8582,6 +9303,7 @@
 8	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 722
+# parallel_id = hk/722
 # text = 因為《基本法》已訂明，立法會主席必須在外國無居留權。
 # translit = yīnwèi«jīběnfǎ»yǐdìngmíng,lìfǎhuìzhǔxíbìxūzàiwàiguówújūliúquán.
 1	因為	因為	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
@@ -8601,6 +9323,7 @@
 15	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 723
+# parallel_id = hk/723
 # text = 而即使兩封信都是由政府發出，但卻不一定是法律文件。
 # translit = 'érjíshǐliǎngfēngxìndōushìyóuzhèngfǔfāchū,dànquèbùyīdìngshìfǎlǜwénjiàn.
 1	而	而	CCONJ	_	_	7	advmod	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -8624,6 +9347,7 @@
 19	。	。	PUNCT	_	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 724
+# parallel_id = hk/724
 # text = 我們最主要想看的是那份「放棄國籍」聲明（Declaration_of_Renunciation_of_British_Citizenship）。
 # translit = wǒmenzuìzhǔyàoxiǎngkàndeshìnàfèn‘fàngqìguójí’shēngmíng(Declaration_of_Renunciation_of_British_Citizenship).
 1	我們	我	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
@@ -8646,6 +9370,7 @@
 18	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 725
+# parallel_id = hk/725
 # text = 而我本人也有一份。
 # translit = 'érwǒběnrényěyǒuyīfèn.
 1	而	而	CCONJ	_	_	5	advmod	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -8658,6 +9383,7 @@
 8	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 726
+# parallel_id = hk/726
 # text = 我們是否應待他收到有關文件。
 # translit = wǒmenshìfǒuyīngdàitāshōudàoyǒuguānwénjiàn.
 1	我們	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
@@ -8673,6 +9399,7 @@
 11	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 727
+# parallel_id = hk/727
 # text = 所有事情皆被正式確認後，才展開選舉程序呢？
 # translit = suǒyǒushìqíngjiēbèizhèngshìquèrènhòu,cáizhǎnkāixuǎnjǔchéngxùne?
 1	所有	所有	DET	_	_	2	det	_	SpaceAfter=No|Translit=suǒyǒu|LTranslit=suǒyǒu
@@ -8691,6 +9418,7 @@
 14	？	？	PUNCT	_	_	10	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 728
+# parallel_id = hk/728
 # text = 好的，謝謝你，毛孟靜議員。
 # translit = hǎode,xièxiènǐ,máo孟jìngyìyuán.
 1	好	好	VERB	_	_	0	root	_	SpaceAfter=No|Translit=hǎo|LTranslit=hǎo
@@ -8704,6 +9432,7 @@
 9	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 729
+# parallel_id = hk/729
 # text = 我剛才說過，你的提問祇能夠涉及選舉過程或與選舉有關的事情。
 # translit = wǒgāngcáishuōguò,nǐdetíwèn祇nénggòushèjíxuǎnjǔguòchénghuòyǔxuǎnjǔyǒuguāndeshìqíng.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -8728,6 +9457,7 @@
 20	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 730
+# parallel_id = hk/730
 # text = 但你卻要求澄清梁君彥議員的國籍問題。
 # translit = dànnǐquèyàoqiú澄qīngliángjūn彥yìyuándeguójíwèntí.
 1	但	但	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -8743,6 +9473,7 @@
 11	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 731
+# parallel_id = hk/731
 # text = 我剛才已作出特別安排，讓梁君彥議員向大家和社會大眾作出澄清及交代。
 # translit = wǒgāngcáiyǐzuòchūtèbié'ānpái,ràngliángjūn彥yìyuánxiàngdàjiāhéshèhuìdàzhòngzuòchū澄qīngjíjiāodài.
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -8767,6 +9498,7 @@
 20	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 732
+# parallel_id = hk/732
 # text = 至於他的答覆能否回應你剛才的提問，我並不能夠提出任何意見。
 # translit = zhìyútādedáfùnéngfǒuhuíyīngnǐgāngcáidetíwèn,wǒbìngbùnénggòutíchūrènhéyìjiàn.
 1	至於	至於	ADP	_	_	7	mark	_	SpaceAfter=No|Translit=zhìyú|LTranslit=zhìyú
@@ -8790,6 +9522,7 @@
 19	。	。	PUNCT	_	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 733
+# parallel_id = hk/733
 # text = 不過，我想對大家說，鑒於梁君彥議員已經一而再、再而三地提供資料，並在公開場合作出澄清，議員大可自行決定稍後會否投票支持他。
 # translit = bùguò,wǒxiǎngduìdàjiāshuō,jiànyúliángjūn彥yìyuányǐjīngyī'érzài,zài'érsāndetígōngzīliào,bìngzàigōngkāichǎnghézuòchū澄qīng,yìyuándàkězìxíngjuédìngshāohòuhuìfǒutóupiàozhīchítā.
 1	不過	不過	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=bùguò|LTranslit=bùguò
@@ -8830,6 +9563,7 @@
 36	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 734
+# parallel_id = hk/734
 # text = 如果大家認為梁君彥議員的答覆未能回應大家的提問，大家可以決定尋求……
 # translit = rúguǒdàjiārènwèiliángjūn彥yìyuándedáfùwèinénghuíyīngdàjiādetíwèn,dàjiākěyǐjuédìngxúnqiú……
 1	如果	如果	SCONJ	_	_	3	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -8853,6 +9587,7 @@
 19	……	……	PUNCT	_	_	17	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 735
+# parallel_id = hk/735
 # text = 那麼梁天琦也不應該被disqualified，對嗎？
 # translit = nàmeliángtiān琦yěbùyīnggāibèidisqualified,duìma?
 1	那麼	那麼	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=nàme|LTranslit=nàme
@@ -8868,6 +9603,7 @@
 11	？	？	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 736
+# parallel_id = hk/736
 # text = 我也不知道梁君彥議員究竟是否真的有合法權利參選，但梁耀忠議員卻要求我們自行考慮是否投票給他嗎？
 # translit = wǒyěbùzhīdàoliángjūn彥yìyuánjiūjìngshìfǒuzhēndeyǒuhéfǎquánlìcānxuǎn,dànliángyàozhōngyìyuánquèyàoqiúwǒmenzìxíngkǎolǜshìfǒutóupiàogěitāma?
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -8902,6 +9638,7 @@
 30	？	？	PUNCT	_	_	20	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 737
+# parallel_id = hk/737
 # text = 你是否也可要求選民自行決定是否投票給梁天琦？
 # translit = nǐshìfǒuyěkěyàoqiúxuǎnmínzìxíngjuédìngshìfǒutóupiàogěiliángtiān琦?
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -8921,6 +9658,7 @@
 15	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 738
+# parallel_id = hk/738
 # text = 由於立法會主席的選舉須按照《議事規則》附表一所訂的程序進行。
 # translit = yóuyúlìfǎhuìzhǔxídexuǎnjǔxū'ànzhào«yìshìguīzé»fùbiǎoyīsuǒdìngdechéngxùjìnxíng.
 1	由於	由於	ADV	_	_	18	advmod	_	SpaceAfter=No|Translit=yóuyú|LTranslit=yóuyú
@@ -8944,6 +9682,7 @@
 19	。	。	PUNCT	_	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 739
+# parallel_id = hk/739
 # text = 而有關的條文是容許議員在選舉主席的會議上，就候選人的事宜進行討論的。
 # translit = 'éryǒuguāndetiáowénshìróngxǔyìyuánzàixuǎnjǔzhǔxídehuìyìshàng,jiùhouxuǎnréndeshìyijìnxíngtǎolùnde.
 1	而	而	CCONJ	_	_	5	advmod	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -8970,6 +9709,7 @@
 22	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 740
+# parallel_id = hk/740
 # text = 事實上，有關的討論亦已在昨天特別安排的論壇上……
 # translit = shìshíshàng,yǒuguāndetǎolùnyìyǐzàizuótiāntèbié'ānpáidelùn壇shàng……
 1	事實上	事實上	ADV	_	_	8	advmod	_	SpaceAfter=No|Translit=shìshíshàng|LTranslit=shìshíshàng
@@ -8989,6 +9729,7 @@
 15	……	……	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 741
+# parallel_id = hk/741
 # text = 主席，我不是要求討論。
 # translit = zhǔxí,wǒbùshìyàoqiútǎolùn.
 1	主席	主席	NOUN	_	_	5	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -9001,6 +9742,7 @@
 8	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 742
+# parallel_id = hk/742
 # text = 我要求的是法律上的澄清。
 # translit = wǒyàoqiúdeshìfǎlǜshàngde澄qīng.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -9014,6 +9756,7 @@
 9	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 743
+# parallel_id = hk/743
 # text = 他一定要提供一份放棄英國國籍聲明的正式文件。
 # translit = tāyīdìngyàotígōngyīfènfàngqìyīngguóguójíshēngmíngdezhèngshìwénjiàn.
 1	他	他	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -9032,6 +9775,7 @@
 14	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 744
+# parallel_id = hk/744
 # text = 而最好當然是正本。
 # translit = 'érzuìhǎodāngránshìzhèngběn.
 1	而	而	CCONJ	_	_	6	advmod	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -9043,6 +9787,7 @@
 7	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 745
+# parallel_id = hk/745
 # text = 但如果暫時沒有正本，向我們提供一份copy也可以。
 # translit = dànrúguǒzànshíméiyǒuzhèngběn,xiàngwǒmentígōngyīfèncopyyěkěyǐ.
 1	但	但	CCONJ	_	_	9	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -9062,6 +9807,7 @@
 15	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 746
+# parallel_id = hk/746
 # text = 不過，現時已經說得很清楚。
 # translit = bùguò,xiànshíyǐjīngshuōdehěnqīngchu.
 1	不過	不過	CCONJ	_	_	5	advmod	_	SpaceAfter=No|Translit=bùguò|LTranslit=bùguò
@@ -9075,6 +9821,7 @@
 9	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 747
+# parallel_id = hk/747
 # text = 便是按照我的理解，他仍未收到相關文件。
 # translit = biànshì'ànzhàowǒdelǐjiě,tāréngwèishōudàoxiāngguānwénjiàn.
 1	便	便	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=biàn|LTranslit=biàn
@@ -9092,6 +9839,7 @@
 13	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 748
+# parallel_id = hk/748
 # text = 試問我們怎可以在這裡進行選舉的程序呢？
 # translit = shìwènwǒmenzěnkěyǐzàizhèlijìnxíngxuǎnjǔdechéngxùne?
 1	試問	試問	VERB	_	_	0	root	_	SpaceAfter=No|Translit=shìwèn|LTranslit=shìwèn
@@ -9108,6 +9856,7 @@
 12	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 749
+# parallel_id = hk/749
 # text = 據我瞭解，《基本法》訂明立法會主席不能夠擁有任何其他國家的居留權。
 # translit = jùwǒliǎojiě,«jīběnfǎ»dìngmínglìfǎhuìzhǔxíbùnénggòuyōngyǒurènhéqítāguójiādejūliúquán.
 1	據	據	ADP	_	_	3	mark	_	SpaceAfter=No|Translit=jù|LTranslit=jù
@@ -9131,6 +9880,7 @@
 19	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 750
+# parallel_id = hk/750
 # text = 這方面已清楚訂明，但並沒有提及候選人。
 # translit = zhèfāngmiànyǐqīngchudìngmíng,dànbìngméiyǒutíjíhouxuǎnrén.
 1	這	這	DET	_	_	2	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -9147,6 +9897,7 @@
 12	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 751
+# parallel_id = hk/751
 # text = 我今天不是要與大家辯論這個問題，但如果大家想澄清的話，便應該透過其他途徑。
 # translit = wǒjīntiānbùshìyàoyǔdàjiābiànlùnzhègèwèntí,dànrúguǒdàjiāxiǎng澄qīngdehuà,biànyīnggāitòuguòqítātújìng.
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -9175,6 +9926,7 @@
 24	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 752
+# parallel_id = hk/752
 # text = 因為我既非具有法律背景的議員。
 # translit = yīnwèiwǒjìfēijùyǒufǎlǜbèijǐngdeyìyuán.
 1	因為	因為	ADV	_	_	9	advmod	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
@@ -9189,6 +9941,7 @@
 10	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 753
+# parallel_id = hk/753
 # text = 而我這個主席的身份，也不能夠作任何回答。
 # translit = 'érwǒzhègèzhǔxídeshēnfèn,yěbùnénggòuzuòrènhéhuídá.
 1	而	而	CCONJ	_	_	12	advmod	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -9208,6 +9961,7 @@
 15	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 754
+# parallel_id = hk/754
 # text = 我祇能夠⋯⋯
 # translit = wǒ祇nénggòu⋯⋯
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -9216,6 +9970,7 @@
 4	⋯⋯	⋯⋯	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=⋯⋯|LTranslit=⋯⋯
 
 # sent_id = 755
+# parallel_id = hk/755
 # text = 不好意思，我不是特別要為難你，亦覺得這樣插言不禮貌。
 # translit = bùhǎoyìsī,wǒbùshìtèbiéyàowèinánnǐ,yìjuédezhèyàngchāyánbùlǐmào.
 1	不好意思	不好意思	INTJ	_	_	5	discourse	_	SpaceAfter=No|Translit=bùhǎoyìsī|LTranslit=bùhǎoyìsī
@@ -9237,6 +9992,7 @@
 17	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 756
+# parallel_id = hk/756
 # text = 不要緊。
 # translit = bùyàojǐn.
 1	不	不	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -9244,6 +10000,7 @@
 3	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 757
+# parallel_id = hk/757
 # text = ……但按照你剛才的說法，作為立法會主席便不能夠擁有外國居留權。
 # translit = ……dàn'ànzhàonǐgāngcáideshuōfǎ,zuòwèilìfǎhuìzhǔxíbiànbùnénggòuyōngyǒuwàiguójūliúquán.
 1	……	……	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
@@ -9266,6 +10023,7 @@
 18	。	。	PUNCT	_	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 758
+# parallel_id = hk/758
 # text = 但是，如果要進行選舉的話，有人將於稍後半小時，或十分鐘後便會當選主席。
 # translit = dànshì,rúguǒyàojìnxíngxuǎnjǔdehuà,yǒurénjiāngyúshāohòubànxiǎoshí,huòshífēnzhōnghòubiànhuìdāngxuǎnzhǔxí.
 1	但是	但是	ADV	_	_	9	advmod	_	SpaceAfter=No|Translit=dànshì|LTranslit=dànshì
@@ -9294,6 +10052,7 @@
 24	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 759
+# parallel_id = hk/759
 # text = 但他卻未能在今天內向我們提供剛才所說的「放棄國籍」正式聲明。
 # translit = dàntāquèwèinéngzàijīntiānnèixiàngwǒmentígōnggāngcáisuǒshuōde‘fàngqìguójí’zhèngshìshēngmíng.
 1	但	但	ADV	_	_	11	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -9320,6 +10079,7 @@
 22	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 760
+# parallel_id = hk/760
 # text = 你說得對……
 # translit = nǐshuōdeduì……
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -9329,12 +10089,14 @@
 5	……	……	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 761
+# parallel_id = hk/761
 # text = 多謝。
 # translit = duōxiè.
 1	多謝	多謝	VERB	_	_	0	root	_	SpaceAfter=No|Translit=duōxiè|LTranslit=duōxiè
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 762
+# parallel_id = hk/762
 # text = ……就是一旦他當選，發覺條件不符合規定，他便不應該成為主席。
 # translit = ……jiùshìyīdàntādāngxuǎn,fājuétiáojiànbùfúhéguīdìng,tābiànbùyīnggāichéngwèizhǔxí.
 1	……	……	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
@@ -9359,6 +10121,7 @@
 20	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 763
+# parallel_id = hk/763
 # text = 這是正確的。
 # translit = zhèshìzhèngquède.
 1	這	這	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -9368,6 +10131,7 @@
 5	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 764
+# parallel_id = hk/764
 # text = 不過，問題是我不能夠建議他接着該怎樣做，因為我沒有這個身份。
 # translit = bùguò,wèntíshìwǒbùnénggòujiànyìtājiēzhegāizěnyàngzuò,yīnwèiwǒméiyǒuzhègèshēnfèn.
 1	不過	不過	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=bùguò|LTranslit=bùguò
@@ -9393,6 +10157,7 @@
 21	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 765
+# parallel_id = hk/765
 # text = 我祇能夠主持……
 # translit = wǒ祇nénggòuzhǔchí……
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -9402,6 +10167,7 @@
 5	……	……	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 766
+# parallel_id = hk/766
 # text = 主席，那麼你坐在這裡做甚麼？
 # translit = zhǔxí,nàmenǐzuòzàizhèlizuòshénme?
 1	主席	主席	NOUN	_	_	5	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -9416,6 +10182,7 @@
 10	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 767
+# parallel_id = hk/767
 # text = ……你說得對。
 # translit = ……nǐshuōdeduì.
 1	……	……	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
@@ -9426,6 +10193,7 @@
 6	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 768
+# parallel_id = hk/768
 # text = 我也想澄清我坐在這裡做甚麼。
 # translit = wǒyěxiǎng澄qīngwǒzuòzàizhèlizuòshénme.
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -9441,6 +10209,7 @@
 11	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 769
+# parallel_id = hk/769
 # text = 根據《議事規則》，我祇是做兩件事。
 # translit = gēnjù«yìshìguīzé»,wǒ祇shìzuòliǎngjiànshì.
 1	根據	根據	ADP	_	_	4	case	_	SpaceAfter=No|Translit=gēnjù|LTranslit=gēnjù
@@ -9458,6 +10227,7 @@
 13	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 770
+# parallel_id = hk/770
 # text = 第一，主持主席選舉的投票。
 # translit = dìyī,zhǔchízhǔxíxuǎnjǔdetóupiào.
 1	第一	第一	ADJ	_	_	3	advmod	_	SpaceAfter=No|Translit=dìyī|LTranslit=dìyī
@@ -9470,6 +10240,7 @@
 8	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 771
+# parallel_id = hk/771
 # text = 第二，宣布哪位候選人當選。
 # translit = dì'èr,xuānbùnǎwèihouxuǎnréndāngxuǎn.
 1	第二	第二	ADJ	_	_	3	advmod	_	SpaceAfter=No|Translit=dì'èr|LTranslit=dì'èr
@@ -9482,6 +10253,7 @@
 8	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 772
+# parallel_id = hk/772
 # text = 我祇是做這兩件事。
 # translit = wǒ祇shìzuòzhèliǎngjiànshì.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -9494,6 +10266,7 @@
 8	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 773
+# parallel_id = hk/773
 # text = 而不應該做其他事。
 # translit = 'érbùyīnggāizuòqítāshì.
 1	而	而	CCONJ	_	_	4	advmod	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -9505,6 +10278,7 @@
 7	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 774
+# parallel_id = hk/774
 # text = 最後，一個規程問題。
 # translit = zuìhòu,yīgèguīchéngwèntí.
 1	最後	最後	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=zuìhòu|LTranslit=zuìhòu
@@ -9516,6 +10290,7 @@
 7	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 775
+# parallel_id = hk/775
 # text = 為了抗爭，為表示我不同意現時的程序，我現在也走出來，站在你後面不會離開。
 # translit = wèilekàngzhēng,wèibiǎoshìwǒbùtóngyìxiànshídechéngxù,wǒxiànzàiyězǒuchūlái,zhànzàinǐhòumiànbùhuìlíkāi.
 1	為了	為了	ADP	_	_	2	mark	_	SpaceAfter=No|Translit=wèile|LTranslit=wèile
@@ -9546,6 +10321,7 @@
 26	。	。	PUNCT	_	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 776
+# parallel_id = hk/776
 # text = 即使你呼籲我離開，我亦不會離開。
 # translit = jíshǐnǐhū籲wǒlíkāi,wǒyìbùhuìlíkāi.
 1	即使	即使	SCONJ	_	_	3	mark	_	SpaceAfter=No|Translit=jíshǐ|LTranslit=jíshǐ
@@ -9562,6 +10338,7 @@
 12	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 777
+# parallel_id = hk/777
 # text = 大家是否要一直這樣繼續下去呢？
 # translit = dàjiāshìfǒuyàoyīzhízhèyàngjìxùxiàqùne?
 1	大家	大家	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=dàjiā|LTranslit=dàjiā
@@ -9576,6 +10353,7 @@
 10	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 778
+# parallel_id = hk/778
 # text = 如果你不影響大家的投票程序，我是不會阻止你的。
 # translit = rúguǒnǐbùyǐngxiǎngdàjiādetóupiàochéngxù,wǒshìbùhuìzǔzhǐnǐde.
 1	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -9597,6 +10375,7 @@
 17	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 779
+# parallel_id = hk/779
 # text = 不過，在投票前，你首先需要確定我、梁頌恒和姚松炎三位議員的投票權。
 # translit = bùguò,zàitóupiàoqián,nǐshǒuxiānxūyàoquèdìngwǒ,liángsònghénghé姚sōngyánsānwèiyìyuándetóupiàoquán.
 1	不過	不過	CCONJ	_	_	10	advmod	_	SpaceAfter=No|Translit=bùguò|LTranslit=bùguò
@@ -9622,6 +10401,7 @@
 21	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 780
+# parallel_id = hk/780
 # text = 其實，我也無權確定你們是否有權投票。
 # translit = qíshí,wǒyěwúquánquèdìngnǐmenshìfǒuyǒuquántóupiào.
 1	其實	其實	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=qíshí|LTranslit=qíshí
@@ -9640,6 +10420,7 @@
 14	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 781
+# parallel_id = hk/781
 # text = 我祇能夠接受秘書給我的名單，包括候選人和有資格投票的議員。
 # translit = wǒ祇nénggòujiēshòumìshūgěiwǒdemíngdān,bāokuòhouxuǎnrénhéyǒuzīgétóupiàodeyìyuán.
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -9663,6 +10444,7 @@
 19	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 782
+# parallel_id = hk/782
 # text = 其實，你應該向秘書處提出，而不是向我提出，因為我無權代表秘書處說話。
 # translit = qíshí,nǐyīnggāixiàngmìshūchùtíchū,'érbùshìxiàngwǒtíchū,yīnwèiwǒwúquándàibiǎomìshūchùshuōhuà.
 1	其實	其實	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit=qíshí|LTranslit=qíshí
@@ -9690,6 +10472,7 @@
 23	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 783
+# parallel_id = hk/783
 # text = 如果你要提出，可以向秘書處提出。
 # translit = rúguǒnǐyàotíchū,kěyǐxiàngmìshūchùtíchū.
 1	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -9704,6 +10487,7 @@
 10	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 784
+# parallel_id = hk/784
 # text = 第二位想提出規程問題的議員是許智峯議員。
 # translit = dì'èrwèixiǎngtíchūguīchéngwèntídeyìyuánshìxǔzhì峯yìyuán.
 1	第二	第二	ADJ	_	_	2	amod	_	SpaceAfter=No|Translit=dì'èr|LTranslit=dì'èr
@@ -9720,6 +10504,7 @@
 12	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 785
+# parallel_id = hk/785
 # text = 主席，我想你清醒地想想，我們今天是否……
 # translit = zhǔxí,wǒxiǎngnǐqīngxǐngdexiǎngxiǎng,wǒmenjīntiānshìfǒu……
 1	主席	主席	NOUN	_	_	4	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -9738,6 +10523,7 @@
 14	……	……	PUNCT	_	_	12	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 786
+# parallel_id = hk/786
 # text = 我清醒與否不是由你判斷的。
 # translit = wǒqīngxǐngyǔfǒubùshìyóunǐpànduànde.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -9753,6 +10539,7 @@
 11	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 787
+# parallel_id = hk/787
 # text = ……我們是否應該繼續進行會議並選舉主席。
 # translit = ……wǒmenshìfǒuyīnggāijìxùjìnxínghuìyìbìngxuǎnjǔzhǔxí.
 1	……	……	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
@@ -9769,6 +10556,7 @@
 12	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 788
+# parallel_id = hk/788
 # text = 毛孟靜議員和多位非建制派議員剛才說過，我們不信納梁君彥議員已經完全放棄英籍或放棄英國的居留權。
 # translit = máo孟jìngyìyuánhéduōwèifēijiànzhìpàiyìyuángāngcáishuōguò,wǒmenbùxìnnàliángjūn彥yìyuányǐjīngwánquánfàngqìyīngjíhuòfàngqìyīngguódejūliúquán.
 1	毛孟靜	毛孟靜	PROPN	_	_	11	nsubj	_	SpaceAfter=No|Translit=máo孟jìng|LTranslit=máo孟jìng
@@ -9801,6 +10589,7 @@
 28	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 789
+# parallel_id = hk/789
 # text = 在這種情況下，要我們選舉主席並不公道。
 # translit = zàizhèzhǒngqíngkuàngxià,yàowǒmenxuǎnjǔzhǔxíbìngbùgōngdào.
 1	在	在	ADP	_	_	4	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -9819,6 +10608,7 @@
 14	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 790
+# parallel_id = hk/790
 # text = 這是第一點。
 # translit = zhèshìdìyīdiǎn.
 1	這	這	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -9828,6 +10618,7 @@
 5	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 791
+# parallel_id = hk/791
 # text = 第二，站在你身後的數位議員，剛才在宣誓時遇到一些障礙。
 # translit = dì'èr,zhànzàinǐshēnhòudeshùwèiyìyuán,gāngcáizàixuānshìshíyùdàoyīxiēzhàng'ài.
 1	第二	第二	ADV	_	_	16	advmod	_	SpaceAfter=No|Translit=dì'èr|LTranslit=dì'èr
@@ -9851,6 +10642,7 @@
 19	。	。	PUNCT	_	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 792
+# parallel_id = hk/792
 # text = 由於負責監誓的秘書長沒有處理他們的宣誓。
 # translit = yóuyúfùzéjiānshìdemìshūzhǎngméiyǒuchùlǐtāmendexuānshì.
 1	由於	由於	ADP	_	_	7	case	_	SpaceAfter=No|Translit=yóuyú|LTranslit=yóuyú
@@ -9866,6 +10658,7 @@
 11	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 793
+# parallel_id = hk/793
 # text = 並表示他們在稍後舉行的主席選舉中不可以投票。
 # translit = bìngbiǎoshìtāmenzàishāohòujǔxíngdezhǔxíxuǎnjǔzhōngbùkěyǐtóupiào.
 1	並	並	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=bìng|LTranslit=bìng
@@ -9884,6 +10677,7 @@
 14	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 794
+# parallel_id = hk/794
 # text = 但是，多位議員認為，他們所採用的宣誓方式，歷屆立法會議員也曾採用類似方式，卻沒有問題。
 # translit = dànshì,duōwèiyìyuánrènwèi,tāmensuǒcǎiyòngdexuānshìfāngshì,lìjièlìfǎhuìyìyuányěcéngcǎiyònglèishìfāngshì,quèméiyǒuwèntí.
 1	但是	但是	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=dànshì|LTranslit=dànshì
@@ -9916,6 +10710,7 @@
 28	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 795
+# parallel_id = hk/795
 # text = 這證明宣誓過程出現問題。
 # translit = zhèzhèngmíngxuānshìguòchéngchūxiànwèntí.
 1	這	這	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -9927,6 +10722,7 @@
 7	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 796
+# parallel_id = hk/796
 # text = 令數位議員稍後無法進行投票，這個選舉便不會是公平及符合程序公義的選舉。
 # translit = lìngshùwèiyìyuánshāohòuwúfǎjìnxíngtóupiào,zhègèxuǎnjǔbiànbùhuìshìgōngpíngjífúhéchéngxùgōngyìdexuǎnjǔ.
 1	令	令	VERB	_	_	23	advcl	_	SpaceAfter=No|Translit=lìng|LTranslit=lìng
@@ -9955,6 +10751,7 @@
 24	。	。	PUNCT	_	_	23	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 797
+# parallel_id = hk/797
 # text = 我想請你決定，面對那麼多程序公義問題，應否繼續進行會議，選出一位沒有任何代表性的立法會主席？
 # translit = wǒxiǎngqǐngnǐjuédìng,miànduìnàmeduōchéngxùgōngyìwèntí,yīngfǒujìxùjìnxínghuìyì,xuǎnchūyīwèiméiyǒurènhédàibiǎoxìngdelìfǎhuìzhǔxí?
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -9989,6 +10786,7 @@
 30	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 798
+# parallel_id = hk/798
 # text = 主席，你擔任「代理主席」亦不容易。
 # translit = zhǔxí,nǐdānrèn‘dàilǐzhǔxí’yìbùróngyì.
 1	主席	主席	NOUN	_	_	4	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -10005,6 +10803,7 @@
 12	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 799
+# parallel_id = hk/799
 # text = 但是，我支持你執行《議事規則》，包括維持議會的秩序，確保我們選舉主席的程序能夠順利完成。
 # translit = dànshì,wǒzhīchínǐzhíxíng«yìshìguīzé»,bāokuòwéichíyìhuìdezhìxù,quèbǎowǒmenxuǎnjǔzhǔxídechéngxùnénggòushùnlìwánchéng.
 1	但是	但是	ADV	_	_	18	advmod	_	SpaceAfter=No|Translit=dànshì|LTranslit=dànshì
@@ -10036,6 +10835,7 @@
 27	。	。	PUNCT	_	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 800
+# parallel_id = hk/800
 # text = 因為這是憲制工作，亦是全港市民正在看着我們做的事情。
 # translit = yīnwèizhèshìxiànzhìgōngzuò,yìshìquángǎngshìmínzhèngzàikànzhewǒmenzuòdeshìqíng.
 1	因為	因為	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
@@ -10059,6 +10859,7 @@
 19	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 801
+# parallel_id = hk/801
 # text = 此外，我想請你也瞭解一下《議事規則》。
 # translit = cǐwài,wǒxiǎngqǐngnǐyěliǎojiěyīxià«yìshìguīzé».
 1	此外	此外	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=cǐwài|LTranslit=cǐwài
@@ -10077,6 +10878,7 @@
 14	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 802
+# parallel_id = hk/802
 # text = 有議員沒有合理理由而在你身後及旁邊站着。
 # translit = yǒuyìyuánméiyǒuhélǐlǐyóu'érzàinǐshēnhòujípángbiānzhànzhe.
 1	有	有	VERB	_	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu|Cxn=Existential-HavePred
@@ -10095,6 +10897,7 @@
 14	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 803
+# parallel_id = hk/803
 # text = 我恐怕這些議員已涉嫌違反《議事規則》。
 # translit = wǒkǒngpàzhèxiēyìyuányǐshèxiánwéifǎn«yìshìguīzé».
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -10111,6 +10914,7 @@
 12	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 804
+# parallel_id = hk/804
 # text = 希望你考慮請這些議員返回座位。
 # translit = xīwàngnǐkǎolǜqǐngzhèxiēyìyuánfǎnhuízuòwèi.
 1	希望	希望	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xīwàng|LTranslit=xīwàng
@@ -10124,6 +10928,7 @@
 9	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 805
+# parallel_id = hk/805
 # text = 如果他們經過多次勸諭仍不返回座位，我認為你應執行《議事規則》，以維持議會的秩序。
 # translit = rúguǒtāmenjīngguòduōcìquàn諭réngbùfǎnhuízuòwèi,wǒrènwèinǐyīngzhíxíng«yìshìguīzé»,yǐwéichíyìhuìdezhìxù.
 1	如果	如果	SCONJ	_	_	8	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -10154,6 +10959,7 @@
 26	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 806
+# parallel_id = hk/806
 # text = 這是第一點。
 # translit = zhèshìdìyīdiǎn.
 1	這	這	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -10163,6 +10969,7 @@
 5	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 807
+# parallel_id = hk/807
 # text = 第二點是關於議員的投票權。
 # translit = dì'èrdiǎnshìguānyúyìyuándetóupiàoquán.
 1	第二	第二	ADJ	_	_	2	amod	_	SpaceAfter=No|Translit=dì'èr|LTranslit=dì'èr
@@ -10175,6 +10982,7 @@
 8	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 808
+# parallel_id = hk/808
 # text = 我同意你的判斷，便是秘書長已按照法例依法為我們監誓。
 # translit = wǒtóngyìnǐdepànduàn,biànshìmìshūzhǎngyǐ'ànzhàofǎlìyīfǎwèiwǒmenjiānshì.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -10196,6 +11004,7 @@
 17	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 809
+# parallel_id = hk/809
 # text = 我亦認為有數位議員沒有依照誓詞的內容完成宣誓。
 # translit = wǒyìrènwèiyǒushùwèiyìyuánméiyǒuyīzhàoshìcídenèiróngwánchéngxuānshì.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -10215,6 +11024,7 @@
 15	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 810
+# parallel_id = hk/810
 # text = 因此，在選舉主席的過程中不能參與表決。
 # translit = yīncǐ,zàixuǎnjǔzhǔxídeguòchéngzhōngbùnéngcānyǔbiǎojué.
 1	因此	因此	ADV	_	_	11	advmod	_	SpaceAfter=No|Translit=yīncǐ|LTranslit=yīncǐ
@@ -10232,6 +11042,7 @@
 13	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 811
+# parallel_id = hk/811
 # text = 這情況我相信所有議員都明白。
 # translit = zhèqíngkuàngwǒxiāngxìnsuǒyǒuyìyuándōumíngbái.
 1	這	這	DET	_	_	2	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -10245,6 +11056,7 @@
 9	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 812
+# parallel_id = hk/812
 # text = 由於未能完成宣誓，因此不能參與選舉。
 # translit = yóuyúwèinéngwánchéngxuānshì,yīncǐbùnéngcānyǔxuǎnjǔ.
 1	由於	由於	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=yóuyú|LTranslit=yóuyú
@@ -10261,6 +11073,7 @@
 12	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 813
+# parallel_id = hk/813
 # text = 而秘書長亦對所有他懷疑未能完成宣誓議員給予多一次宣誓的機會。
 # translit = 'érmìshūzhǎngyìduìsuǒyǒutāhuáiyíwèinéngwánchéngxuānshìyìyuángěiyǔduōyīcìxuānshìdejīhuì.
 1	而	而	CCONJ	_	_	13	advmod	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -10285,6 +11098,7 @@
 20	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 814
+# parallel_id = hk/814
 # text = 我認為這做法已經兼顧到人情上的考慮。
 # translit = wǒrènwèizhèzuòfǎyǐjīngjiāngùdàorénqíngshàngdekǎolǜ.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -10301,6 +11115,7 @@
 12	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 815
+# parallel_id = hk/815
 # text = 第三點，至於大家質疑梁君彥議員的國籍問題，我早已很關心此事，並多次請梁議員澄清，要求他確認。
 # translit = dìsāndiǎn,zhìyúdàjiāzhìyíliángjūn彥yìyuándeguójíwèntí,wǒzǎoyǐhěnguānxīncǐshì,bìngduōcìqǐngliángyìyuán澄qīng,yàoqiútāquèrèn.
 1	第三	第三	ADJ	_	_	2	amod	_	SpaceAfter=No|Translit=dìsān|LTranslit=dìsān
@@ -10337,6 +11152,7 @@
 32	。	。	PUNCT	_	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 816
+# parallel_id = hk/816
 # text = 而他已多次確定地表示事情已經處理好。
 # translit = 'értāyǐduōcìquèdìngdebiǎoshìshìqíngyǐjīngchùlǐhǎo.
 1	而	而	CCONJ	_	_	7	advmod	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -10353,6 +11169,7 @@
 12	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 817
+# parallel_id = hk/817
 # text = 及後，亦已提供英國領事館發出的兩封信，供大家參閱。
 # translit = jíhòu,yìyǐtígōngyīngguólǐngshìguǎnfāchūdeliǎngfēngxìn,gōngdàjiācānyuè.
 1	及後	及後	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=jíhòu|LTranslit=jíhòu
@@ -10374,6 +11191,7 @@
 17	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 818
+# parallel_id = hk/818
 # text = 當然，議員可以要求梁議員提供一份證書。
 # translit = dāngrán,yìyuánkěyǐyàoqiúliángyìyuántígōngyīfènzhèngshū.
 1	當然	當然	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=dāngrán|LTranslit=dāngrán
@@ -10390,6 +11208,7 @@
 12	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 819
+# parallel_id = hk/819
 # text = 這點我是理解的。
 # translit = zhèdiǎnwǒshìlǐjiěde.
 1	這	這	DET	_	_	2	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -10401,6 +11220,7 @@
 7	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 820
+# parallel_id = hk/820
 # text = 但我看過那兩封信後，最低限度認為到此刻，沒有其他新證據指梁議員的英籍問題並未處理。
 # translit = dànwǒkànguònàliǎngfēngxìnhòu,zuìdīxiàndùrènwèidàocǐkè,méiyǒuqítāxīnzhèngjùzhǐliángyìyuándeyīngjíwèntíbìngwèichùlǐ.
 1	但	但	ADV	_	_	12	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -10434,6 +11254,7 @@
 29	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 821
+# parallel_id = hk/821
 # text = 既然已定了今天選舉主席，我認為我們應按照所訂定的時間安排順利完成選舉主席。
 # translit = jìrányǐdìnglejīntiānxuǎnjǔzhǔxí,wǒrènwèiwǒmenyīng'ànzhàosuǒdìngdìngdeshíjiān'ānpáishùnlìwánchéngxuǎnjǔzhǔxí.
 1	既然	既然	SCONJ	_	_	11	mark	_	SpaceAfter=No|Translit=jìrán|LTranslit=jìrán
@@ -10462,6 +11283,7 @@
 24	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 822
+# parallel_id = hk/822
 # text = 正如其他選舉一樣，有人可能會質疑不同候選人的某些聲明有誤。
 # translit = zhèngrúqítāxuǎnjǔyīyàng,yǒurénkěnénghuìzhìyíbùtónghouxuǎnréndemǒuxiēshēngmíngyǒuwù.
 1	正如	正如	ADP	_	_	3	mark	_	SpaceAfter=No|Translit=zhèngrú|LTranslit=zhèngrú
@@ -10483,6 +11305,7 @@
 17	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 823
+# parallel_id = hk/823
 # text = 大家日後可以透過不同方式跟進，包括司法覆核或其他法律程序。
 # translit = dàjiārìhòukěyǐtòuguòbùtóngfāngshìgēnjìn,bāokuòsīfǎfùhéhuòqítāfǎlǜchéngxù.
 1	大家	大家	PRON	_	_	7	nsubj	_	SpaceAfter=No|Translit=dàjiā|LTranslit=dàjiā
@@ -10503,6 +11326,7 @@
 16	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 824
+# parallel_id = hk/824
 # text = 作為議員我們都很理解。
 # translit = zuòwèiyìyuánwǒmendōuhěnlǐjiě.
 1	作為	作為	ADP	_	_	2	case	_	SpaceAfter=No|Translit=zuòwèi|LTranslit=zuòwèi
@@ -10514,6 +11338,7 @@
 7	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 825
+# parallel_id = hk/825
 # text = 我希望梁耀忠議員可以公平、公正地主持會議，確保我們能夠順利選出主席。
 # translit = wǒxīwàngliángyàozhōngyìyuánkěyǐgōngpíng,gōngzhèngdezhǔchíhuìyì,quèbǎowǒmennénggòushùnlìxuǎnchūzhǔxí.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -10538,6 +11363,7 @@
 20	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 826
+# parallel_id = hk/826
 # text = 主席，我留意到有些同事就兩位候選人的其中一人的資格提出了意見或質疑。
 # translit = zhǔxí,wǒliúyìdàoyǒuxiētóngshìjiùliǎngwèihouxuǎnréndeqízhōngyīréndezīgétíchūleyìjiànhuòzhìyí.
 1	主席	主席	NOUN	_	_	4	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -10566,6 +11392,7 @@
 24	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 827
+# parallel_id = hk/827
 # text = 但我相信在這個會議廳內，雖然不同政治立場的議員對此事抱持不同的態度，但亦不能因此而阻礙今天既定的議程。
 # translit = dànwǒxiāngxìnzàizhègèhuìyìtīngnèi,suīránbùtóngzhèngzhìlìchǎngdeyìyuánduìcǐshìbàochíbùtóngdetàidù,dànyìbùnéngyīncǐ'érzǔ'àijīntiānjìdìngdeyìchéng.
 1	但	但	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -10606,6 +11433,7 @@
 36	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 828
+# parallel_id = hk/828
 # text = 由我們完成宣誓至今，我相信已浪費了兩小時。
 # translit = yóuwǒmenwánchéngxuānshìzhìjīn,wǒxiāngxìnyǐlàngfèileliǎngxiǎoshí.
 1	由	由	ADP	_	_	4	mark	_	SpaceAfter=No|Translit=yóu|LTranslit=yóu
@@ -10624,6 +11452,7 @@
 14	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 829
+# parallel_id = hk/829
 # text = 而閣下的工作亦祇是主持今天這項主席選舉，所以我希望你不要再浪費時間，直接進入立法會主席選舉的程序。
 # translit = 'ér閣xiàdegōngzuòyì祇shìzhǔchíjīntiānzhèxiàngzhǔxíxuǎnjǔ,suǒyǐwǒxīwàngnǐbùyàozàilàngfèishíjiān,zhíjiējìnrùlìfǎhuìzhǔxíxuǎnjǔdechéngxù.
 1	而	而	CCONJ	_	_	7	advmod	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -10659,12 +11488,14 @@
 31	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 830
+# parallel_id = hk/830
 # text = 謝謝。
 # translit = xièxiè.
 1	謝謝	謝謝	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xièxiè|LTranslit=xièxiè
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 831
+# parallel_id = hk/831
 # text = 主席，毛孟靜議員剛才提到一個觀點，就是按照最嚴謹、最謹慎、合理的做法。
 # translit = zhǔxí,máo孟jìngyìyuángāngcáitídàoyīgèguāndiǎn,jiùshì'ànzhàozuìyánjǐn,zuìjǐnshèn,hélǐdezuòfǎ.
 1	主席	主席	NOUN	_	_	6	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -10693,6 +11524,7 @@
 24	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 832
+# parallel_id = hk/832
 # text = 在我們看到正式文件前，實難以單憑一封電郵或相關文件的副本予以確認，即使我們相信他。
 # translit = zàiwǒmenkàndàozhèngshìwénjiànqián,shínányǐdānpíngyīfēngdiànyóuhuòxiāngguānwénjiàndefùběnyǔyǐquèrèn,jíshǐwǒmenxiāngxìntā.
 1	在	在	ADP	_	_	3	mark	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -10724,6 +11556,7 @@
 27	。	。	PUNCT	_	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 833
+# parallel_id = hk/833
 # text = 我認為今次選舉主席，後果十分重大，足以帶來憲制危機。
 # translit = wǒrènwèijīncìxuǎnjǔzhǔxí,hòuguǒshífēnzhòngdà,zúyǐdàiláixiànzhìwēijī.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -10744,6 +11577,7 @@
 16	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 834
+# parallel_id = hk/834
 # text = 我們是否必須如此草率、倉促地處理？
 # translit = wǒmenshìfǒubìxūrúcǐcǎolǜ,cāngcùdechùlǐ?
 1	我們	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
@@ -10759,6 +11593,7 @@
 11	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 835
+# parallel_id = hk/835
 # text = 另一點，剛才也有同事提到，就《英國國籍法》所訂有關取消國籍和居留權的問題上，我認為當中仍有爭議。
 # translit = lìngyīdiǎn,gāngcáiyěyǒutóngshìtídào,jiù«yīngguóguójífǎ»suǒdìngyǒuguānqǔxiāoguójíhéjūliúquándewèntíshàng,wǒrènwèidāngzhōngréngyǒuzhēngyì.
 1	另	另	DET	_	_	3	det	_	SpaceAfter=No|Translit=lìng|LTranslit=lìng
@@ -10797,6 +11632,7 @@
 34	。	。	PUNCT	_	_	29	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 836
+# parallel_id = hk/836
 # text = 而我們似乎未有充分諮詢法律意見。
 # translit = 'érwǒmenshìhuwèiyǒuchōngfēn諮xúnfǎlǜyìjiàn.
 1	而	而	CCONJ	_	_	7	advmod	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -10811,6 +11647,7 @@
 10	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 837
+# parallel_id = hk/837
 # text = 在此情況下，就《基本法》第七十一條所指的外國居留權問題，我認為在未澄清之前，是否必須在這一刻選舉立法會主席？
 # translit = zàicǐqíngkuàngxià,jiù«jīběnfǎ»dìqīshíyītiáosuǒzhǐdewàiguójūliúquánwèntí,wǒrènwèizàiwèi澄qīngzhīqián,shìfǒubìxūzàizhèyīkèxuǎnjǔlìfǎhuìzhǔxí?
 1	在	在	ADP	_	_	3	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -10851,6 +11688,7 @@
 36	？	？	PUNCT	_	_	20	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 838
+# parallel_id = hk/838
 # text = 剛才提到規程問題。
 # translit = gāngcáitídàoguīchéngwèntí.
 1	剛才	剛才	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=gāngcái|LTranslit=gāngcái
@@ -10860,6 +11698,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 839
+# parallel_id = hk/839
 # text = 你說你的責任是主持會議，以及在得出結果後，作出宣佈。
 # translit = nǐshuōnǐdezérènshìzhǔchíhuìyì,yǐjízàidechūjiéguǒhòu,zuòchūxuān佈.
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -10884,6 +11723,7 @@
 20	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 840
+# parallel_id = hk/840
 # text = 其實有一件事情是否也屬於你的權力範圍，就是中止整個會議？
 # translit = qíshíyǒuyījiànshìqíngshìfǒuyěshǔyúnǐdequánlìfànwéi,jiùshìzhōngzhǐzhěnggèhuìyì?
 1	其實	其實	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=qíshí|LTranslit=qíshí
@@ -10908,6 +11748,7 @@
 20	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 841
+# parallel_id = hk/841
 # text = 面對這些法律觀點或風險，你認為今天是否不適宜就選舉立法會主席作出決定？
 # translit = miànduìzhèxiēfǎlǜguāndiǎnhuòfēngxiǎn,nǐrènwèijīntiānshìfǒubùshìyijiùxuǎnjǔlìfǎhuìzhǔxízuòchūjuédìng?
 1	面對	面對	VERB	_	_	9	advcl	_	SpaceAfter=No|Translit=miànduì|LTranslit=miànduì
@@ -10934,6 +11775,7 @@
 22	？	？	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 842
+# parallel_id = hk/842
 # text = 多謝主席。
 # translit = duōxièzhǔxí.
 1	多謝	多謝	VERB	_	_	0	root	_	SpaceAfter=No|Translit=duōxiè|LTranslit=duōxiè
@@ -10941,6 +11783,7 @@
 3	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 843
+# parallel_id = hk/843
 # text = 我是第一次參與立法會會議。
 # translit = wǒshìdìyīcìcānyǔlìfǎhuìhuìyì.
 1	我	我	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -10953,6 +11796,7 @@
 8	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 844
+# parallel_id = hk/844
 # text = 正如李慧琼議員所言，很多香港人正在觀看和關注這次會議。
 # translit = zhèngrúlihuì琼yìyuánsuǒyán,hěnduōxiānggǎngrénzhèngzàiguānkànhéguānzhùzhècìhuìyì.
 1	正如	正如	ADP	_	_	5	mark	_	SpaceAfter=No|Translit=zhèngrú|LTranslit=zhèngrú
@@ -10974,6 +11818,7 @@
 17	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 845
+# parallel_id = hk/845
 # text = 正因如此，我們對自己應有更高的要求。
 # translit = zhèngyīnrúcǐ,wǒmenduìzìjǐyīngyǒugènggāodeyàoqiú.
 1	正	正	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=zhèng|LTranslit=zhèng
@@ -10992,6 +11837,7 @@
 14	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 846
+# parallel_id = hk/846
 # text = 剛才我留意到最大的問題是甚麼？
 # translit = gāngcáiwǒliúyìdàozuìdàdewèntíshìshénme?
 1	剛才	剛才	ADV	_	_	9	advmod	_	SpaceAfter=No|Translit=gāngcái|LTranslit=gāngcái
@@ -11006,6 +11852,7 @@
 10	？	？	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 847
+# parallel_id = hk/847
 # text = 我仍是一名大學生。
 # translit = wǒréngshìyīmíngdàxuéshēng.
 1	我	我	PRON	_	_	6	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -11017,6 +11864,7 @@
 7	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 848
+# parallel_id = hk/848
 # text = 但這次選舉的嚴謹程度比大學學生會選舉更不如。
 # translit = dànzhècìxuǎnjǔdeyánjǐnchéngdùbǐdàxuéxuéshēnghuìxuǎnjǔgèngbùrú.
 1	但	但	ADV	_	_	13	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -11035,6 +11883,7 @@
 14	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 849
+# parallel_id = hk/849
 # text = 怎可能在尚未確定候選人的國籍便開展整個程式？
 # translit = zěnkěnéngzàishàngwèiquèdìnghouxuǎnréndeguójíbiànkāizhǎnzhěnggèchéngshì?
 1	怎	怎	ADV	_	_	11	advmod	_	SpaceAfter=No|Translit=zěn|LTranslit=zěn|CxnElt=11:Interrogative-WHInfo-Direct.WHWord
@@ -11053,6 +11902,7 @@
 14	？	？	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 850
+# parallel_id = hk/850
 # text = 他現在祇是口頭表示……
 # translit = tāxiànzài祇shìkǒutóubiǎoshì……
 1	他	他	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -11064,6 +11914,7 @@
 7	……	……	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 851
+# parallel_id = hk/851
 # text = 雖然有人指那些信件可證實其事，但都不過是口頭上的確認。
 # translit = suīrányǒurénzhǐnàxiēxìnjiànkězhèngshíqíshì,dàndōubùguòshìkǒutóushàngdequèrèn.
 1	雖然	雖然	SCONJ	_	_	2	mark	_	SpaceAfter=No|Translit=suīrán|LTranslit=suīrán
@@ -11087,6 +11938,7 @@
 19	。	。	PUNCT	_	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 852
+# parallel_id = hk/852
 # text = 倘若秘書處和主席對整個選舉負責，或覺得整個立法會要取信於民，重新取得市民的信任，便更要將每個程式做得更嚴謹，而非「按章工作」，即秘書處說不需要查便不查。
 # translit = tǎngruòmìshūchùhézhǔxíduìzhěnggèxuǎnjǔfùzé,huòjuédezhěnggèlìfǎhuìyàoqǔxìnyúmín,zhòngxīnqǔdeshìmíndexìnrèn,biàngèngyàojiāngměigèchéngshìzuòdegèngyánjǐn,'érfēi‘'ànzhānggōngzuò’,jímìshūchùshuōbùxūyàochábiànbùchá.
 1	倘若	倘若	SCONJ	_	_	8	mark	_	SpaceAfter=No|Translit=tǎngruò|LTranslit=tǎngruò
@@ -11143,6 +11995,7 @@
 52	。	。	PUNCT	_	_	30	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 853
+# parallel_id = hk/853
 # text = 要求提供一份書面和具有法律效力的文件，本應很簡單。
 # translit = yàoqiútígōngyīfènshūmiànhéjùyǒufǎlǜxiàolìdewénjiàn,běnyīnghěnjiǎndān.
 1	要求	要求	VERB	_	_	15	advcl	_	SpaceAfter=No|Translit=yàoqiú|LTranslit=yàoqiú
@@ -11163,6 +12016,7 @@
 16	。	。	PUNCT	_	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 854
+# parallel_id = hk/854
 # text = 即使我參加學生會選舉，亦需提供學生證，證明我是大學的學生。
 # translit = jíshǐwǒcānjiāxuéshēnghuìxuǎnjǔ,yìxūtígōngxuéshēngzhèng,zhèngmíngwǒshìdàxuédexuéshēng.
 1	即使	即使	SCONJ	_	_	3	mark	_	SpaceAfter=No|Translit=jíshǐ|LTranslit=jíshǐ
@@ -11185,6 +12039,7 @@
 18	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 855
+# parallel_id = hk/855
 # text = 主席，如果連如此簡單的程序也不能完成，整個立法會不可能取信於人。
 # translit = zhǔxí,rúguǒliánrúcǐjiǎndāndechéngxùyěbùnéngwánchéng,zhěnggèlìfǎhuìbùkěnéngqǔxìnyúrén.
 1	主席	主席	NOUN	_	_	18	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -11208,6 +12063,7 @@
 19	。	。	PUNCT	_	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 856
+# parallel_id = hk/856
 # text = 這是第一個問題。
 # translit = zhèshìdìyīgèwèntí.
 1	這	這	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -11218,6 +12074,7 @@
 6	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 857
+# parallel_id = hk/857
 # text = 第二個問題，我們現在尚未弄清楚多少議員能夠投票。
 # translit = dì'èrgèwèntí,wǒmenxiànzàishàngwèinòngqīngchuduōshǎoyìyuánnénggòutóupiào.
 1	第二	第二	ADJ	_	_	3	amod	_	SpaceAfter=No|Translit=dì'èr|LTranslit=dì'èr
@@ -11237,6 +12094,7 @@
 15	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 858
+# parallel_id = hk/858
 # text = 《議事規則》最基本的精神是確保每位議員有充足機會完成宣誓程序。
 # translit = «yìshìguīzé»zuìjīběndejīngshénshìquèbǎoměiwèiyìyuányǒuchōngzújīhuìwánchéngxuānshìchéngxù.
 1	《	《	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -11261,6 +12119,7 @@
 20	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 859
+# parallel_id = hk/859
 # text = 而秘書長不能基於完全沒有法律理據的無理質疑，憑其個人判斷向其他議員表示他沒有能力主持監誓。
 # translit = 'érmìshūzhǎngbùnéngjīyúwánquánméiyǒufǎlǜlǐjùdewúlǐzhìyí,píngqígèrénpànduànxiàngqítāyìyuánbiǎoshìtāméiyǒunénglìzhǔchíjiānshì.
 1	而	而	CCONJ	_	_	21	advmod	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -11292,6 +12151,7 @@
 27	。	。	PUNCT	_	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 860
+# parallel_id = hk/860
 # text = 我認為這是完全違反了《議事規則》應有的精神。
 # translit = wǒrènwèizhèshìwánquánwéifǎnle«yìshìguīzé»yīngyǒudejīngshén.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -11312,6 +12172,7 @@
 16	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 861
+# parallel_id = hk/861
 # text = 即讓所有議員能夠成功完成宣誓程式，然後才進行立法會主席選舉。
 # translit = jíràngsuǒyǒuyìyuánnénggòuchénggōngwánchéngxuānshìchéngshì,ránhòucáijìnxínglìfǎhuìzhǔxíxuǎnjǔ.
 1	即	即	ADV	_	_	13	advmod	_	SpaceAfter=No|Translit=jí|LTranslit=jí
@@ -11333,6 +12194,7 @@
 17	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 862
+# parallel_id = hk/862
 # text = 所以，秘書長陳維安剛才的決定或判斷完全是arbitrary_use_of_power，是完全沒有任何基礎的判斷。
 # translit = suǒyǐ,mìshūzhǎngchénwéi'āngāngcáidejuédìnghuòpànduànwánquánshìarbitrary_use_of_power,shìwánquánméiyǒurènhéjīchǔdepànduàn.
 1	所以	所以	ADV	_	_	12	advmod	_	SpaceAfter=No|Translit=suǒyǐ|LTranslit=suǒyǐ
@@ -11358,6 +12220,7 @@
 21	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 863
+# parallel_id = hk/863
 # text = 如果大家翻看剛才錄影片段，其實三位議員已完整讀完誓詞。
 # translit = rúguǒdàjiāfānkàngāngcáilùyǐngpiànduàn,qíshísānwèiyìyuányǐwánzhěngdúwánshìcí.
 1	如果	如果	SCONJ	_	_	3	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -11379,6 +12242,7 @@
 17	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 864
+# parallel_id = hk/864
 # text = 而《議事規則》祇規定議員要完整讀出誓詞。
 # translit = 'ér«yìshìguīzé»祇guīdìngyìyuányàowánzhěngdúchūshìcí.
 1	而	而	ADV	_	_	7	advmod	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -11397,6 +12261,7 @@
 14	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 865
+# parallel_id = hk/865
 # text = 所以秘書長不能以語氣或其他條件為標準，判斷他無權監誓。
 # translit = suǒyǐmìshūzhǎngbùnéngyǐyǔqìhuòqítātiáojiànwèibiāozhǔn,pànduàntāwúquánjiānshì.
 1	所以	所以	ADV	_	_	11	advmod	_	SpaceAfter=No|Translit=suǒyǐ|LTranslit=suǒyǐ
@@ -11418,6 +12283,7 @@
 17	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 866
+# parallel_id = hk/866
 # text = 我希望主席明白大家面前有兩大問題。
 # translit = wǒxīwàngzhǔxímíngbáidàjiāmiànqiányǒuliǎngdàwèntí.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -11433,6 +12299,7 @@
 11	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 867
+# parallel_id = hk/867
 # text = 如果我們不先處理這些問題，然後才進行主席選舉，立法會便難以取信於人。
 # translit = rúguǒwǒmenbùxiānchùlǐzhèxiēwèntí,ránhòucáijìnxíngzhǔxíxuǎnjǔ,lìfǎhuìbiànnányǐqǔxìnyúrén.
 1	如果	如果	SCONJ	_	_	5	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -11456,6 +12323,7 @@
 19	。	。	PUNCT	_	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 868
+# parallel_id = hk/868
 # text = 我相信很多議員，包括眾多有廣大民意基礎支持的直選議員，都不能信納這次選舉結果。
 # translit = wǒxiāngxìnhěnduōyìyuán,bāokuòzhòngduōyǒuguǎngdàmínyìjīchǔzhīchídezhíxuǎnyìyuán,dōubùnéngxìnnàzhècìxuǎnjǔjiéguǒ.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -11485,6 +12353,7 @@
 25	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 869
+# parallel_id = hk/869
 # text = 主席，今天我們向香港人展示一個粗疏得不能再粗疏的程序。
 # translit = zhǔxí,jīntiānwǒmenxiàngxiānggǎngrénzhǎnshìyīgècūshūdebùnéngzàicūshūdechéngxù.
 1	主席	主席	NOUN	_	_	8	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -11508,6 +12377,7 @@
 19	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 870
+# parallel_id = hk/870
 # text = 梁君彥議員連正本都拿不出來證明自己的國籍。
 # translit = liángjūn彥yìyuánliánzhèngběndōunábùchūláizhèngmíngzìjǐdeguójí.
 1	梁君彥	梁君彥	PROPN	_	_	2	compound	_	SpaceAfter=No|Translit=liángjūn彥|LTranslit=liángjūn彥
@@ -11525,6 +12395,7 @@
 13	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 871
+# parallel_id = hk/871
 # text = 祇提供一份副本不像副本的文件。
 # translit = 祇tígōngyīfènfùběnbùxiàngfùběndewénjiàn.
 1	祇	祇	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=祇|LTranslit=祇
@@ -11540,6 +12411,7 @@
 11	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 872
+# parallel_id = hk/872
 # text = 最糟糕的是，他連居留權都未能釐清。
 # translit = zuìzāogāodeshì,tāliánjūliúquándōuwèinéng釐qīng.
 1	最	最	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=zuì|LTranslit=zuì
@@ -11557,6 +12429,7 @@
 13	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 873
+# parallel_id = hk/873
 # text = 如果我們今天在一種如此粗疏的情況下進入選舉立法會的程序，主席，就是讓梁君彥議員「過了海便是神仙」。
 # translit = rúguǒwǒmenjīntiānzàiyīzhǒngrúcǐcūshūdeqíngkuàngxiàjìnrùxuǎnjǔlìfǎhuìdechéngxù,zhǔxí,jiùshìràngliángjūn彥yìyuán‘guòlehǎibiànshìshénxian’.
 1	如果	如果	SCONJ	_	_	13	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -11595,6 +12468,7 @@
 34	。	。	PUNCT	_	_	22	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 874
+# parallel_id = hk/874
 # text = 他當然樂意。
 # translit = tādāngránlèyì.
 1	他	他	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -11603,6 +12477,7 @@
 4	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 875
+# parallel_id = hk/875
 # text = 我覺得大家剛才問的問題都很具體。
 # translit = wǒjuédedàjiāgāngcáiwèndewèntídōuhěnjùtǐ.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -11618,6 +12493,7 @@
 11	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 876
+# parallel_id = hk/876
 # text = 候選人的資格以至哪些議員合資格投票，我們都未能釐清。
 # translit = houxuǎnréndezīgéyǐzhìnǎxiēyìyuánhézīgétóupiào,wǒmendōuwèinéng釐qīng.
 1	候選人	候選人	NOUN	_	_	3	nmod	_	SpaceAfter=No|Translit=houxuǎnrén|LTranslit=houxuǎnrén
@@ -11638,6 +12514,7 @@
 16	。	。	PUNCT	_	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 877
+# parallel_id = hk/877
 # text = 在如此混亂、粗疏的情況下進入選舉程序，主席，我怕你背負的壓力會很大。
 # translit = zàirúcǐhùnluàn,cūshūdeqíngkuàngxiàjìnrùxuǎnjǔchéngxù,zhǔxí,wǒpànǐbèifùdeyālìhuìhěndà.
 1	在	在	ADP	_	_	7	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -11666,6 +12543,7 @@
 24	。	。	PUNCT	_	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 878
+# parallel_id = hk/878
 # text = 因此，我希望主席你能夠耐心聆聽議員的意見，然後作出裁決。
 # translit = yīncǐ,wǒxīwàngzhǔxínǐnénggòunàixīn聆tīngyìyuándeyìjiàn,ránhòuzuòchūcáijué.
 1	因此	因此	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=yīncǐ|LTranslit=yīncǐ
@@ -11687,6 +12565,7 @@
 17	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 879
+# parallel_id = hk/879
 # text = 如果在一種如此不能服眾的情況下進行立法會主席選舉，香港人是會看到的。
 # translit = rúguǒzàiyīzhǒngrúcǐbùnéngfúzhòngdeqíngkuàngxiàjìnxínglìfǎhuìzhǔxíxuǎnjǔ,xiānggǎngrénshìhuìkàndàode.
 1	如果	如果	SCONJ	_	_	12	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -11715,6 +12594,7 @@
 24	。	。	PUNCT	_	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 880
+# parallel_id = hk/880
 # text = 謝謝主席。
 # translit = xièxièzhǔxí.
 1	謝謝	謝謝	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xièxiè|LTranslit=xièxiè
@@ -11722,6 +12602,7 @@
 3	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 881
+# parallel_id = hk/881
 # text = 主席，對於你剛才所說，「祇有立法會主席才有居留權限制，候選人沒有」，我完全不能接受。
 # translit = zhǔxí,duìyúnǐgāngcáisuǒshuō,‘祇yǒulìfǎhuìzhǔxícáiyǒujūliúquánxiànzhì,houxuǎnrénméiyǒu’,wǒwánquánbùnéngjiēshòu.
 1	主席	主席	NOUN	_	_	26	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -11753,6 +12634,7 @@
 27	。	。	PUNCT	_	_	26	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 882
+# parallel_id = hk/882
 # text = 如果我們這一刻進行投票，當選者下一刻便成為立法會主席。
 # translit = rúguǒwǒmenzhèyīkèjìnxíngtóupiào,dāngxuǎnzhěxiàyīkèbiànchéngwèilìfǎhuìzhǔxí.
 1	如果	如果	SCONJ	_	_	6	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -11774,6 +12656,7 @@
 17	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 883
+# parallel_id = hk/883
 # text = 因此，我們絕對有義務釐清他已完成所有放棄英國居留權的手續，並且交出正本，以正視聽。
 # translit = yīncǐ,wǒmenjuéduìyǒuyìwu釐qīngtāyǐwánchéngsuǒyǒufàngqìyīngguójūliúquándeshǒuxù,bìngqiějiāochūzhèngběn,yǐzhèngshìtīng.
 1	因此	因此	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=yīncǐ|LTranslit=yīncǐ
@@ -11804,6 +12687,7 @@
 26	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 884
+# parallel_id = hk/884
 # text = 立法會秘書處亦有責任維護這個程序正確和完整地進行。
 # translit = lìfǎhuìmìshūchùyìyǒuzérènwéihùzhègèchéngxùzhèngquèhéwánzhěngdejìnxíng.
 1	立法會	立法會	NOUN	_	_	2	compound	_	SpaceAfter=No|Translit=lìfǎhuì|LTranslit=lìfǎhuì
@@ -11822,6 +12706,7 @@
 14	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 885
+# parallel_id = hk/885
 # text = 所以，如果梁君彥議員仍然無法交出蓋有正規印章的信件正本，他應該不符合參選資格。
 # translit = suǒyǐ,rúguǒliángjūn彥yìyuánréngránwúfǎjiāochūgàiyǒuzhèngguīyìnzhāngdexìnjiànzhèngběn,tāyīnggāibùfúhécānxuǎnzīgé.
 1	所以	所以	ADV	_	_	21	advmod	_	SpaceAfter=No|Translit=suǒyǐ|LTranslit=suǒyǐ
@@ -11850,6 +12735,7 @@
 24	。	。	PUNCT	_	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 886
+# parallel_id = hk/886
 # text = 除了設置兩個投票箱，分別供投廢票和投給塗謹申議員，我們是否還要為梁君彥議員設置投票箱？
 # translit = chúleshèzhìliǎnggètóupiàoxiāng,fēnbiégōngtóufèipiàohétóugěi塗jǐnshēnyìyuán,wǒmenshìfǒuháiyàowèiliángjūn彥yìyuánshèzhìtóupiàoxiāng?
 1	除了	除了	ADP	_	_	2	mark	_	SpaceAfter=No|Translit=chúle|LTranslit=chúle
@@ -11881,6 +12767,7 @@
 27	？	？	PUNCT	_	_	18	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 887
+# parallel_id = hk/887
 # text = 這相當影響未來立法會任期內會議如何進行，跟全港公眾利益也有莫大關係。
 # translit = zhèxiāngdāngyǐngxiǎngwèiláilìfǎhuìrènqīnèihuìyìrúhéjìnxíng,gēnquángǎnggōngzhònglìyìyěyǒumòdàguānxì.
 1	這	這	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -11906,6 +12793,7 @@
 21	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 888
+# parallel_id = hk/888
 # text = 我認為這一刻一定要處理這件事。
 # translit = wǒrènwèizhèyīkèyīdìngyàochùlǐzhèjiànshì.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -11922,6 +12810,7 @@
 12	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 889
+# parallel_id = hk/889
 # text = 如果梁君彥議員無法交出文件正本，他應該不符合參選資格。
 # translit = rúguǒliángjūn彥yìyuánwúfǎjiāochūwénjiànzhèngběn,tāyīnggāibùfúhécānxuǎnzīgé.
 1	如果	如果	SCONJ	_	_	5	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -11942,6 +12831,7 @@
 16	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 890
+# parallel_id = hk/890
 # text = 我剛才祇是依書直說，向大家引述《基本法》的內容，並沒有加入個人意見。
 # translit = wǒgāngcái祇shìyīshūzhíshuō,xiàngdàjiāyǐnshù«jīběnfǎ»denèiróng,bìngméiyǒujiārùgèrényìjiàn.
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -11967,6 +12857,7 @@
 21	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 891
+# parallel_id = hk/891
 # text = 由於主席不應加入個人意見，況且當中涉及憲制和法律的問題，我不宜給予任何意見。
 # translit = yóuyúzhǔxíbùyīngjiārùgèrényìjiàn,kuàngqiědāngzhōngshèjíxiànzhìhéfǎlǜdewèntí,wǒbùyigěiyǔrènhéyìjiàn.
 1	由於	由於	ADP	_	_	5	mark	_	SpaceAfter=No|Translit=yóuyú|LTranslit=yóuyú
@@ -11995,6 +12886,7 @@
 24	。	。	PUNCT	_	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 892
+# parallel_id = hk/892
 # text = 即使我提出意見，也未必是最正確無誤。
 # translit = jíshǐwǒtíchūyìjiàn,yěwèibìshìzuìzhèngquèwúwù.
 1	即使	即使	SCONJ	_	_	3	mark	_	SpaceAfter=No|Translit=jíshǐ|LTranslit=jíshǐ
@@ -12012,6 +12904,7 @@
 13	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 893
+# parallel_id = hk/893
 # text = 祇供大家參考而已。
 # translit = 祇gōngdàjiācānkǎo'éryǐ.
 1	祇	祇	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=祇|LTranslit=祇
@@ -12022,6 +12915,7 @@
 6	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 894
+# parallel_id = hk/894
 # text = 任何一項選舉，不論是我以往參加過的學生會選舉，以至今天立法會主席的選舉……
 # translit = rènhéyīxiàngxuǎnjǔ,bùlùnshìwǒyǐwǎngcānjiāguòdexuéshēnghuìxuǎnjǔ,yǐzhìjīntiānlìfǎhuìzhǔxídexuǎnjǔ……
 1	任何	任何	DET	_	_	4	det	_	SpaceAfter=No|Translit=rènhé|LTranslit=rènhé
@@ -12049,6 +12943,7 @@
 23	……	……	PUNCT	_	_	22	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 895
+# parallel_id = hk/895
 # text = 主席，如果這是正式會議，梁頌恒議員沒有資格參加這個會議。
 # translit = zhǔxí,rúguǒzhèshìzhèngshìhuìyì,liángsònghéngyìyuánméiyǒuzīgécānjiāzhègèhuìyì.
 1	主席	主席	NOUN	_	_	11	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -12069,6 +12964,7 @@
 16	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 896
+# parallel_id = hk/896
 # text = 主席，那麼我修正我第一個問題。
 # translit = zhǔxí,nàmewǒxiūzhèngwǒdìyīgèwèntí.
 1	主席	主席	NOUN	_	_	5	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -12083,6 +12979,7 @@
 10	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 897
+# parallel_id = hk/897
 # text = 我想問我現在究竟有沒有權參加這個會議？
 # translit = wǒxiǎngwènwǒxiànzàijiūjìngyǒuméiyǒuquáncānjiāzhègèhuìyì?
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -12101,6 +12998,7 @@
 14	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 898
+# parallel_id = hk/898
 # text = 主席，根據《議事規則》和相關法例，任何未宣誓的議員不能參加正式會議和發言。
 # translit = zhǔxí,gēnjù«yìshìguīzé»héxiāngguānfǎlì,rènhéwèixuānshìdeyìyuánbùnéngcānjiāzhèngshìhuìyìhéfāyán.
 1	主席	主席	NOUN	_	_	19	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -12129,6 +13027,7 @@
 24	。	。	PUNCT	_	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 899
+# parallel_id = hk/899
 # text = 主席，那麼我下一個問題來了。
 # translit = zhǔxí,nàmewǒxiàyīgèwèntíláile.
 1	主席	主席	NOUN	_	_	9	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -12144,6 +13043,7 @@
 11	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 900
+# parallel_id = hk/900
 # text = 《議事規則》第十二條《每屆任期的首次會議》訂明……
 # translit = «yìshìguīzé»dìshí'èrtiáo«měijièrènqīdeshǒucìhuìyì»dìngmíng……
 1	《	《	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -12166,6 +13066,7 @@
 18	……	……	PUNCT	_	_	16	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 901
+# parallel_id = hk/901
 # text = （一）在立法會每屆任期首次會議上，議員須按照本議事規則第一條《宗教式或非宗教式宣誓》的規定作宗教式或非宗教式宣誓。
 # translit = (yī)zàilìfǎhuìměijièrènqīshǒucìhuìyìshàng,yìyuánxū'ànzhàoběnyìshìguīzédìyītiáo«zōngjiàoshìhuòfēizōngjiàoshìxuānshì»deguīdìngzuòzōngjiàoshìhuòfēizōngjiàoshìxuānshì.
 1	（	（	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=(|LTranslit=(
@@ -12209,6 +13110,7 @@
 39	。	。	PUNCT	_	_	32	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 902
+# parallel_id = hk/902
 # text = （二）在所有出席會議的議員……「──包括我──」作宗教式或非宗教式宣誓後，須按照本議事規則第四條《立法會主席的選擧》規定的程序進行立法會主席的選擧。
 # translit = ('èr)zàisuǒyǒuchūxíhuìyìdeyìyuán……‘──bāokuòwǒ──’zuòzōngjiàoshìhuòfēizōngjiàoshìxuānshìhòu,xū'ànzhàoběnyìshìguīzédìsìtiáo«lìfǎhuìzhǔxídexuǎn擧»guīdìngdechéngxùjìnxínglìfǎhuìzhǔxídexuǎn擧.
 1	（	（	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=(|LTranslit=(
@@ -12260,6 +13162,7 @@
 47	。	。	PUNCT	_	_	42	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 903
+# parallel_id = hk/903
 # text = 主席，這裏涉及先後次序的問題。
 # translit = zhǔxí,zhè裏shèjíxiānhòucìxùdewèntí.
 1	主席	主席	NOUN	_	_	4	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -12273,6 +13176,7 @@
 9	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 904
+# parallel_id = hk/904
 # text = 我們尚未完成第一款的程序，即所有出席這次會議的議員進行宣誓。
 # translit = wǒmenshàngwèiwánchéngdìyīkuǎndechéngxù,jísuǒyǒuchūxízhècìhuìyìdeyìyuánjìnxíngxuānshì.
 1	我們	我	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
@@ -12297,6 +13201,7 @@
 20	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 905
+# parallel_id = hk/905
 # text = 試問怎能進入第二款選舉立法會主席的程序？
 # translit = shìwènzěnnéngjìnrùdì'èrkuǎnxuǎnjǔlìfǎhuìzhǔxídechéngxù?
 1	試問	試問	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=shìwèn|LTranslit=shìwèn
@@ -12313,6 +13218,7 @@
 12	？	？	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 906
+# parallel_id = hk/906
 # text = 這是很嚴重的規程問題。
 # translit = zhèshìhěnyánzhòngdeguīchéngwèntí.
 1	這	這	PRON	_	_	7	nsubj	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -12325,6 +13231,7 @@
 8	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 907
+# parallel_id = hk/907
 # text = 既然我已容許其他議員就座，便不會作出不容許議員發言的決定。
 # translit = jìránwǒyǐróngxǔqítāyìyuánjiùzuò,biànbùhuìzuòchūbùróngxǔyìyuánfāyándejuédìng.
 1	既然	既然	SCONJ	_	_	4	mark	_	SpaceAfter=No|Translit=jìrán|LTranslit=jìrán
@@ -12348,6 +13255,7 @@
 19	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 908
+# parallel_id = hk/908
 # text = 我會讓他發言。
 # translit = wǒhuìràngtāfāyán.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -12358,6 +13266,7 @@
 6	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 909
+# parallel_id = hk/909
 # text = 主席，如果你確認這是一個正式會議，你這樣做嚴重違反了《議事規則》第一條的規定。
 # translit = zhǔxí,rúguǒnǐquèrènzhèshìyīgèzhèngshìhuìyì,nǐzhèyàngzuòyánzhòngwéifǎnle«yìshìguīzé»dìyītiáodeguīdìng.
 1	主席	主席	NOUN	_	_	17	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -12389,6 +13298,7 @@
 27	。	。	PUNCT	_	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 910
+# parallel_id = hk/910
 # text = 我希望你重新考慮。
 # translit = wǒxīwàngnǐzhòngxīnkǎolǜ.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -12399,6 +13309,7 @@
 6	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 911
+# parallel_id = hk/911
 # text = 我認為要改選主席。
 # translit = wǒrènwèiyàogǎixuǎnzhǔxí.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -12409,6 +13320,7 @@
 6	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 912
+# parallel_id = hk/912
 # text = 我和應謝偉俊議員。
 # translit = wǒhéyīngxièwěi俊yìyuán.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -12418,6 +13330,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 913
+# parallel_id = hk/913
 # text = 他不稱職。
 # translit = tābùchēngzhí.
 1	他	他	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -12426,6 +13339,7 @@
 4	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 914
+# parallel_id = hk/914
 # text = 要改選主席。
 # translit = yàogǎixuǎnzhǔxí.
 1	要	要	AUX	_	_	2	aux	_	SpaceAfter=No|Translit=yào|LTranslit=yào
@@ -12434,6 +13348,7 @@
 4	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 915
+# parallel_id = hk/915
 # text = 你可以提出質疑，但我已作了決定。
 # translit = nǐkěyǐtíchūzhìyí,dànwǒyǐzuòlejuédìng.
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -12450,6 +13365,7 @@
 12	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 916
+# parallel_id = hk/916
 # text = 在席議員是經過選舉確認的議員，雖然他未宣誓，但我會容許他發言。
 # translit = zàixíyìyuánshìjīngguòxuǎnjǔquèrèndeyìyuán,suīrántāwèixuānshì,dànwǒhuìróngxǔtāfāyán.
 1	在席	在席	ADJ	_	_	2	amod	_	SpaceAfter=No|Translit=zàixí|LTranslit=zàixí
@@ -12475,6 +13391,7 @@
 21	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 917
+# parallel_id = hk/917
 # text = 你可以有你的決定。
 # translit = nǐkěyǐyǒunǐdejuédìng.
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -12486,6 +13403,7 @@
 7	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 918
+# parallel_id = hk/918
 # text = 但我想知道，你的決定是否建基於你認為有關議員是否應該正式宣誓？
 # translit = dànwǒxiǎngzhīdào,nǐdejuédìngshìfǒujiànjīyúnǐrènwèiyǒuguānyìyuánshìfǒuyīnggāizhèngshìxuānshì?
 1	但	但	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -12509,6 +13427,7 @@
 19	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 919
+# parallel_id = hk/919
 # text = 如果你認為他的宣誓有效而准許他發言，你可以此為基礎作出決定。
 # translit = rúguǒnǐrènwèitādexuānshìyǒuxiào'érzhǔnxǔtāfāyán,nǐkěyǐcǐwèijīchǔzuòchūjuédìng.
 1	如果	如果	SCONJ	_	_	3	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -12534,6 +13453,7 @@
 21	。	。	PUNCT	_	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 920
+# parallel_id = hk/920
 # text = 但如果你同意有關宣誓不合理和不合法，你這樣做便嚴重違反了《議事規則》第一條。
 # translit = dànrúguǒnǐtóngyìyǒuguānxuānshìbùhélǐhébùhéfǎ,nǐzhèyàngzuòbiànyánzhòngwéifǎnle«yìshìguīzé»dìyītiáo.
 1	但	但	ADV	_	_	18	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -12564,6 +13484,7 @@
 26	。	。	PUNCT	_	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 921
+# parallel_id = hk/921
 # text = 即使任何議員未曾作最後宣誓，他仍具議員的資格，這是就其身份而言。
 # translit = jíshǐrènhéyìyuánwèicéngzuòzuìhòuxuānshì,tāréngjùyìyuándezīgé,zhèshìjiùqíshēnfèn'éryán.
 1	即使	即使	SCONJ	_	_	5	mark	_	SpaceAfter=No|Translit=jíshǐ|LTranslit=jíshǐ
@@ -12591,6 +13512,7 @@
 23	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 922
+# parallel_id = hk/922
 # text = 當然，你可以說他尚未宣誓，尚未是議員。
 # translit = dāngrán,nǐkěyǐshuōtāshàngwèixuānshì,shàngwèishìyìyuán.
 1	當然	當然	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=dāngrán|LTranslit=dāngrán
@@ -12610,6 +13532,7 @@
 15	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 923
+# parallel_id = hk/923
 # text = 但問題是你剛才尚未宣誓，我已容許你就座。
 # translit = dànwèntíshìnǐgāngcáishàngwèixuānshì,wǒyǐróngxǔnǐjiùzuò.
 1	但	但	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -12629,6 +13552,7 @@
 15	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 924
+# parallel_id = hk/924
 # text = 你又如何解釋呢？
 # translit = nǐyòurúhéjiěshìne?
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -12639,6 +13563,7 @@
 6	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 925
+# parallel_id = hk/925
 # text = 主席，當你宣佈進入選舉主席的第二階段，便已確認完成了第一階段的宣誓儀式。
 # translit = zhǔxí,dāngnǐxuān佈jìnrùxuǎnjǔzhǔxídedì'èrjiēduàn,biànyǐquèrènwánchéngledìyījiēduàndexuānshìyíshì.
 1	主席	主席	NOUN	_	_	15	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -12666,6 +13591,7 @@
 23	。	。	PUNCT	_	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 926
+# parallel_id = hk/926
 # text = 所以，你不要搞錯這個邏輯。
 # translit = suǒyǐ,nǐbùyàogǎocuòzhègèluóji.
 1	所以	所以	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=suǒyǐ|LTranslit=suǒyǐ
@@ -12680,6 +13606,7 @@
 10	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 927
+# parallel_id = hk/927
 # text = 你說得對。
 # translit = nǐshuōdeduì.
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -12689,6 +13616,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 928
+# parallel_id = hk/928
 # text = 不過問題在於尚未有人取消他的資格，他是未宣誓。
 # translit = bùguòwèntízàiyúshàngwèiyǒurénqǔxiāotādezīgé,tāshìwèixuānshì.
 1	不過	不過	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=bùguò|LTranslit=bùguò
@@ -12710,6 +13638,7 @@
 17	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 929
+# parallel_id = hk/929
 # text = 你先前在會議上就座，沒有人取消你的資格，所以你有資格宣誓。
 # translit = nǐxiānqiánzàihuìyìshàngjiùzuò,méiyǒurénqǔxiāonǐdezīgé,suǒyǐnǐyǒuzīgéxuānshì.
 1	你	你	PRON	_	_	6	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -12735,6 +13664,7 @@
 21	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 930
+# parallel_id = hk/930
 # text = 我是指他發言，主席。
 # translit = wǒshìzhǐtāfāyán,zhǔxí.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -12747,6 +13677,7 @@
 8	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 931
+# parallel_id = hk/931
 # text = 不是取消資格。
 # translit = bùshìqǔxiāozīgé.
 1	不	不	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -12756,6 +13687,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 932
+# parallel_id = hk/932
 # text = 這是下一步會處理的問題。
 # translit = zhèshìxiàyībùhuìchùlǐdewèntí.
 1	這	這	PRON	_	_	9	nsubj	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -12770,6 +13702,7 @@
 10	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 933
+# parallel_id = hk/933
 # text = 我祇是提出，議員要完成第一階段的宣誓，才有資格進入第二階段參與會議。
 # translit = wǒ祇shìtíchū,yìyuányàowánchéngdìyījiēduàndexuānshì,cáiyǒuzīgéjìnrùdì'èrjiēduàncānyǔhuìyì.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -12796,6 +13729,7 @@
 22	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 934
+# parallel_id = hk/934
 # text = 你可以質疑我的做法。
 # translit = nǐkěyǐzhìyíwǒdezuòfǎ.
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -12807,6 +13741,7 @@
 7	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 935
+# parallel_id = hk/935
 # text = 但我認為按照剛才的程序，你們尚未宣誓已有資格在會議廳就座，我是基於這個理念作出決定。
 # translit = dànwǒrènwèi'ànzhàogāngcáidechéngxù,nǐmenshàngwèixuānshìyǐyǒuzīgézàihuìyìtīngjiùzuò,wǒshìjīyúzhègèlǐniànzuòchūjuédìng.
 1	但	但	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -12837,6 +13772,7 @@
 26	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 936
+# parallel_id = hk/936
 # text = 你問我理據是甚麼，我已向你作出解釋。
 # translit = nǐwènwǒlǐjùshìshénme,wǒyǐxiàngnǐzuòchūjiěshì.
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -12855,6 +13791,7 @@
 14	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 937
+# parallel_id = hk/937
 # text = 無論你接受與否，又或我的決定是對或錯。
 # translit = wúlùnnǐjiēshòuyǔfǒu,yòuhuòwǒdejuédìngshìduìhuòcuò.
 1	無論	無論	SCONJ	_	_	3	mark	_	SpaceAfter=No|Translit=wúlùn|LTranslit=wúlùn
@@ -12875,6 +13812,7 @@
 16	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 938
+# parallel_id = hk/938
 # text = 如果你仍視我為主席，並稱呼我為主席，你便要接受我的決定。
 # translit = rúguǒnǐréngshìwǒwèizhǔxí,bìngchēnghūwǒwèizhǔxí,nǐbiànyàojiēshòuwǒdejuédìng.
 1	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -12901,6 +13839,7 @@
 22	。	。	PUNCT	_	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 939
+# parallel_id = hk/939
 # text = 除非你不把我當作主席，那就不用理會我這決定。
 # translit = chúfēinǐbùbǎwǒdāngzuòzhǔxí,nàjiùbùyònglǐhuìwǒzhèjuédìng.
 1	除非	除非	SCONJ	_	_	6	mark	_	SpaceAfter=No|Translit=chúfēi|LTranslit=chúfēi
@@ -12921,6 +13860,7 @@
 16	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 940
+# parallel_id = hk/940
 # text = 梁頌恒議員，你是否要繼續發言？
 # translit = liángsònghéngyìyuán,nǐshìfǒuyàojìxùfāyán?
 1	梁頌恒	梁頌恒	PROPN	_	_	7	vocative	_	SpaceAfter=No|Translit=liángsònghéng|LTranslit=liángsònghéng
@@ -12934,6 +13874,7 @@
 9	？	？	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 941
+# parallel_id = hk/941
 # text = 主席，我明白你不想當「醜人」，但你不可以違反《議事規則》。
 # translit = zhǔxí,wǒmíngbáinǐbùxiǎngdāng‘醜rén’,dànnǐbùkěyǐwéifǎn«yìshìguīzé».
 1	主席	主席	NOUN	_	_	4	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -12960,6 +13901,7 @@
 22	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 942
+# parallel_id = hk/942
 # text = 《議事規則》第一條訂明，議員未宣誓便不能參與會議。
 # translit = «yìshìguīzé»dìyītiáodìngmíng,yìyuánwèixuānshìbiànbùnéngcānyǔhuìyì.
 1	《	《	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -12981,6 +13923,7 @@
 17	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 943
+# parallel_id = hk/943
 # text = 你可以提出質疑，但我剛才已作出決定。
 # translit = nǐkěyǐtíchūzhìyí,dànwǒgāngcáiyǐzuòchūjuédìng.
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -12997,6 +13940,7 @@
 12	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 944
+# parallel_id = hk/944
 # text = 你沒有權overrule《議事規則》作出這決定。
 # translit = nǐméiyǒuquánoverrule«yìshìguīzé»zuòchūzhèjuédìng.
 1	你	你	PRON	_	_	9	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -13013,6 +13957,7 @@
 12	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 945
+# parallel_id = hk/945
 # text = 你根本沒有power作出這決定。
 # translit = nǐgēnběnméiyǒupowerzuòchūzhèjuédìng.
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -13026,6 +13971,7 @@
 9	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 946
+# parallel_id = hk/946
 # text = 我已說了。
 # translit = wǒyǐshuōle.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -13035,6 +13981,7 @@
 5	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 947
+# parallel_id = hk/947
 # text = 我的決定可以是錯或對。
 # translit = wǒdejuédìngkěyǐshìcuòhuòduì.
 1	我	我	PRON	_	_	3	nmod	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -13048,6 +13995,7 @@
 9	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 948
+# parallel_id = hk/948
 # text = 但無論如何，我今天不會跟你爭論。
 # translit = dànwúlùnrúhé,wǒjīntiānbùhuìgēnnǐzhēnglùn.
 1	但	但	ADV	_	_	11	advmod	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -13064,6 +14012,7 @@
 12	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 949
+# parallel_id = hk/949
 # text = 這是錯的決定。
 # translit = zhèshìcuòdejuédìng.
 1	這	這	PRON	_	_	5	nsubj	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -13074,6 +14023,7 @@
 6	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 950
+# parallel_id = hk/950
 # text = 你是否要作出違反《議事規則》的決定？
 # translit = nǐshìfǒuyàozuòchūwéifǎn«yìshìguīzé»dejuédìng?
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -13090,6 +14040,7 @@
 12	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 951
+# parallel_id = hk/951
 # text = 我已作出決定。
 # translit = wǒyǐzuòchūjuédìng.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -13099,6 +14050,7 @@
 5	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 952
+# parallel_id = hk/952
 # text = 如果你不同意我的決定，可以向法庭提出質疑。
 # translit = rúguǒnǐbùtóngyìwǒdejuédìng,kěyǐxiàngfǎtíngtíchūzhìyí.
 1	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No|Translit=rúguǒ|LTranslit=rúguǒ
@@ -13117,6 +14069,7 @@
 14	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 953
+# parallel_id = hk/953
 # text = 為何你這些話不跟他們說？
 # translit = wèihénǐzhèxiēhuàbùgēntāmenshuō?
 1	為何	為何	ADV	_	_	8	advmod	_	SpaceAfter=No|Translit=wèihé|LTranslit=wèihé
@@ -13130,6 +14083,7 @@
 9	？	？	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 954
+# parallel_id = hk/954
 # text = 為何你不叫他們向法庭提出要執行你的決定？
 # translit = wèihénǐbùjiàotāmenxiàngfǎtíngtíchūyàozhíxíngnǐdejuédìng?
 1	為何	為何	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=wèihé|LTranslit=wèihé
@@ -13148,6 +14102,7 @@
 14	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 955
+# parallel_id = hk/955
 # text = 我不是已決定了嗎？
 # translit = wǒbùshìyǐjuédìnglema?
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -13160,6 +14115,7 @@
 8	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 956
+# parallel_id = hk/956
 # text = 為何你這些話祇對我說，卻不對你身旁的人說？
 # translit = wèihénǐzhèxiēhuà祇duìwǒshuō,quèbùduìnǐshēnpángderénshuō?
 1	為何	為何	ADV	_	_	8	advmod	_	SpaceAfter=No|Translit=wèihé|LTranslit=wèihé
@@ -13182,6 +14138,7 @@
 18	？	？	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 957
+# parallel_id = hk/957
 # text = 我已經作出決定，讓他發言。
 # translit = wǒyǐjīngzuòchūjuédìng,ràngtāfāyán.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -13195,6 +14152,7 @@
 9	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 958
+# parallel_id = hk/958
 # text = 梁耀忠，為何要這樣呢？
 # translit = liángyàozhōng,wèihéyàozhèyàngne?
 1	梁耀忠	梁耀忠	PROPN	_	_	5	vocative	_	SpaceAfter=No|Translit=liángyàozhōng|LTranslit=liángyàozhōng
@@ -13206,6 +14164,7 @@
 7	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 959
+# parallel_id = hk/959
 # text = 你可否保持中立和公正，按照《議事規則》來辦事？
 # translit = nǐkěfǒubǎochízhōnglìhégōngzhèng,'ànzhào«yìshìguīzé»láibànshì?
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -13225,6 +14184,7 @@
 15	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 960
+# parallel_id = hk/960
 # text = 我知道你不會當「醜人」，也不想為難你。
 # translit = wǒzhīdàonǐbùhuìdāng‘醜rén’,yěbùxiǎngwèinánnǐ.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -13245,6 +14205,7 @@
 16	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 961
+# parallel_id = hk/961
 # text = 你祇需按照《議事規則》便可以。
 # translit = nǐ祇xū'ànzhào«yìshìguīzé»biànkěyǐ.
 1	你	你	PRON	_	_	10	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -13260,6 +14221,7 @@
 11	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 962
+# parallel_id = hk/962
 # text = 根據《議事規則》，我作的決定便是最終決定。
 # translit = gēnjù«yìshìguīzé»,wǒzuòdejuédìngbiànshìzuìzhōngjuédìng.
 1	根據	根據	ADP	_	_	4	case	_	SpaceAfter=No|Translit=gēnjù|LTranslit=gēnjù
@@ -13279,6 +14241,7 @@
 15	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 963
+# parallel_id = hk/963
 # text = 主席，規程問題。
 # translit = zhǔxí,guīchéngwèntí.
 1	主席	主席	NOUN	_	_	4	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -13288,6 +14251,7 @@
 5	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 964
+# parallel_id = hk/964
 # text = 請大家先坐下。
 # translit = qǐngdàjiāxiānzuòxià.
 1	請	請	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǐng|LTranslit=qǐng
@@ -13298,6 +14262,7 @@
 6	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 965
+# parallel_id = hk/965
 # text = 規程問題：主席，立法會是莊嚴的地方。
 # translit = guīchéngwèntí:zhǔxí,lìfǎhuìshìzhuāngyándedefāng.
 1	規程	規程	NOUN	_	_	2	compound	_	SpaceAfter=No|Translit=guīchéng|LTranslit=guīchéng
@@ -13313,6 +14278,7 @@
 11	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 966
+# parallel_id = hk/966
 # text = 希望你請那些在你身旁的議員返回座位。
 # translit = xīwàngnǐqǐngnàxiēzàinǐshēnpángdeyìyuánfǎnhuízuòwèi.
 1	希望	希望	VERB	_	_	0	root	_	SpaceAfter=No|Translit=xīwàng|LTranslit=xīwàng
@@ -13329,6 +14295,7 @@
 12	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 967
+# parallel_id = hk/967
 # text = 請大家坐下，並保持肅靜。
 # translit = qǐngdàjiāzuòxià,bìngbǎochísùjìng.
 1	請	請	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǐng|LTranslit=qǐng
@@ -13342,6 +14309,7 @@
 9	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 968
+# parallel_id = hk/968
 # text = 梁美芬議員，我還未批准你發言，請坐下。
 # translit = liángměifēnyìyuán,wǒháiwèipīzhǔnnǐfāyán,qǐngzuòxià.
 1	梁美芬	梁美芬	PROPN	_	_	7	vocative	_	SpaceAfter=No|Translit=liángměifēn|LTranslit=liángměifēn
@@ -13360,6 +14328,7 @@
 14	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 969
+# parallel_id = hk/969
 # text = 我不是插隊發言，主席。
 # translit = wǒbùshìchāduìfāyán,zhǔxí.
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -13372,6 +14341,7 @@
 8	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 970
+# parallel_id = hk/970
 # text = 我希望在你身旁的議員可以返回座位，因為我們感到很騷擾。
 # translit = wǒxīwàngzàinǐshēnpángdeyìyuánkěyǐfǎnhuízuòwèi,yīnwèiwǒmengǎndàohěn騷rǎo.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -13393,6 +14363,7 @@
 17	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 971
+# parallel_id = hk/971
 # text = 我們希望主席你一個人主持會議。
 # translit = wǒmenxīwàngzhǔxínǐyīgèrénzhǔchíhuìyì.
 1	我們	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
@@ -13407,6 +14378,7 @@
 10	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 972
+# parallel_id = hk/972
 # text = 不應有五個人垂簾聽政。
 # translit = bùyīngyǒuwǔgèrénchuí簾tīngzhèng.
 1	不	不	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=bù|LTranslit=bù
@@ -13419,6 +14391,7 @@
 8	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 973
+# parallel_id = hk/973
 # text = 你不需要這些人來保護，對嗎？
 # translit = nǐbùxūyàozhèxiērénláibǎohù,duìma?
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -13434,6 +14407,7 @@
 11	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 974
+# parallel_id = hk/974
 # text = 梁美芬教授……
 # translit = liángměifēnjiàoshòu……
 1	梁美芬	梁美芬	PROPN	_	_	0	root	_	SpaceAfter=No|Translit=liángměifēn|LTranslit=liángměifēn
@@ -13441,6 +14415,7 @@
 3	……	……	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 975
+# parallel_id = hk/975
 # text = ……我們感到非常騷擾。
 # translit = ……wǒmengǎndàofēicháng騷rǎo.
 1	……	……	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
@@ -13451,6 +14426,7 @@
 6	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 976
+# parallel_id = hk/976
 # text = 我希望主席裁決。
 # translit = wǒxīwàngzhǔxícáijué.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -13460,6 +14436,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 977
+# parallel_id = hk/977
 # text = 請這五位議員返回座位，因為立法會《議事規則》……
 # translit = qǐngzhèwǔwèiyìyuánfǎnhuízuòwèi,yīnwèilìfǎhuì«yìshìguīzé»……
 1	請	請	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǐng|LTranslit=qǐng
@@ -13479,6 +14456,7 @@
 15	……	……	PUNCT	_	_	13	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 978
+# parallel_id = hk/978
 # text = 剛才的會議本來進行得很好……
 # translit = gāngcáidehuìyìběnláijìnxíngdehěnhǎo……
 1	剛才	剛才	NOUN	_	_	3	nmod	_	SpaceAfter=No|Translit=gāngcái|LTranslit=gāngcái
@@ -13492,6 +14470,7 @@
 9	……	……	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 979
+# parallel_id = hk/979
 # text = ……第四十二條清楚訂明……
 # translit = ……dìsìshí'èrtiáoqīngchudìngmíng……
 1	……	……	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
@@ -13503,6 +14482,7 @@
 7	……	……	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 980
+# parallel_id = hk/980
 # text = ……祇是你們提出這些問題，會議便不能進行。
 # translit = ……祇shìnǐmentíchūzhèxiēwèntí,huìyìbiànbùnéngjìnxíng.
 1	……	……	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
@@ -13521,6 +14501,7 @@
 14	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 981
+# parallel_id = hk/981
 # text = ……主席，我希望你要求那五位議員返回座位……
 # translit = ……zhǔxí,wǒxīwàngnǐyàoqiúnàwǔwèiyìyuánfǎnhuízuòwèi……
 1	……	……	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
@@ -13539,6 +14520,7 @@
 14	……	……	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 982
+# parallel_id = hk/982
 # text = 梁美芬議員，我還未叫喚你發言。
 # translit = liángměifēnyìyuán,wǒháiwèijiàohuànnǐfāyán.
 1	梁美芬	梁美芬	PROPN	_	_	7	vocative	_	SpaceAfter=No|Translit=liángměifēn|LTranslit=liángměifēn
@@ -13553,6 +14535,7 @@
 10	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 983
+# parallel_id = hk/983
 # text = 請你先坐下。
 # translit = qǐngnǐxiānzuòxià.
 1	請	請	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǐng|LTranslit=qǐng
@@ -13563,6 +14546,7 @@
 6	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 984
+# parallel_id = hk/984
 # text = 下一位是陳志全議員。
 # translit = xiàyīwèishìchénzhìquányìyuán.
 1	下	下	DET	_	_	3	det	_	SpaceAfter=No|Translit=xià|LTranslit=xià
@@ -13574,6 +14558,7 @@
 7	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 985
+# parallel_id = hk/985
 # text = 梁頌恒議員尚未說完。
 # translit = liángsònghéngyìyuánshàngwèishuōwán.
 1	梁頌恒	梁頌恒	PROPN	_	_	5	nsubj	_	SpaceAfter=No|Translit=liángsònghéng|LTranslit=liángsònghéng
@@ -13585,6 +14570,7 @@
 7	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 986
+# parallel_id = hk/986
 # text = 梁頌恒議員，你剛才坐下來。
 # translit = liángsònghéngyìyuán,nǐgāngcáizuòxiàlái.
 1	梁頌恒	梁頌恒	PROPN	_	_	6	vocative	_	SpaceAfter=No|Translit=liángsònghéng|LTranslit=liángsònghéng
@@ -13597,6 +14583,7 @@
 8	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 987
+# parallel_id = hk/987
 # text = 我以為你已發言完畢。
 # translit = wǒyǐwèinǐyǐfāyánwánbì.
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No|Translit=wǒ|LTranslit=wǒ
@@ -13608,6 +14595,7 @@
 7	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 988
+# parallel_id = hk/988
 # text = 請你繼續。
 # translit = qǐngnǐjìxù.
 1	請	請	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǐng|LTranslit=qǐng
@@ -13616,6 +14604,7 @@
 4	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 989
+# parallel_id = hk/989
 # text = 主席，我忘記說到哪里。
 # translit = zhǔxí,wǒwàngjìshuōdàonǎlǐ.
 1	主席	主席	NOUN	_	_	4	vocative	_	SpaceAfter=No|Translit=zhǔxí|LTranslit=zhǔxí
@@ -13628,6 +14617,7 @@
 8	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 990
+# parallel_id = hk/990
 # text = 剛才較為混亂。
 # translit = gāngcáijiàowèihùnluàn.
 1	剛才	剛才	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=gāngcái|LTranslit=gāngcái
@@ -13636,6 +14626,7 @@
 4	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 991
+# parallel_id = hk/991
 # text = 其實，在選舉中……
 # translit = qíshí,zàixuǎnjǔzhōng……
 1	其實	其實	ADV	_	_	4	advmod	_	SpaceAfter=No|Translit=qíshí|LTranslit=qíshí
@@ -13646,6 +14637,7 @@
 6	……	……	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=……|LTranslit=……
 
 # sent_id = 992
+# parallel_id = hk/992
 # text = 請議員坐下。
 # translit = qǐngyìyuánzuòxià.
 1	請	請	VERB	_	_	0	root	_	SpaceAfter=No|Translit=qǐng|LTranslit=qǐng
@@ -13655,6 +14647,7 @@
 5	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 993
+# parallel_id = hk/993
 # text = 在我叫喚議員發言前，請先坐下。
 # translit = zàiwǒjiàohuànyìyuánfāyánqián,qǐngxiānzuòxià.
 1	在	在	ADP	_	_	3	mark:rel	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -13671,6 +14664,7 @@
 12	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 994
+# parallel_id = hk/994
 # text = 梁頌恒議員，請繼續發言。
 # translit = liángsònghéngyìyuán,qǐngjìxùfāyán.
 1	梁頌恒	梁頌恒	PROPN	_	_	4	vocative	_	SpaceAfter=No|Translit=liángsònghéng|LTranslit=liángsònghéng
@@ -13682,6 +14676,7 @@
 7	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 995
+# parallel_id = hk/995
 # text = 在任何選舉中，最重要的兩點就是候選人資格及選民基礎。
 # translit = zàirènhéxuǎnjǔzhōng,zuìzhòngyàodeliǎngdiǎnjiùshìhouxuǎnrénzīgéjíxuǎnmínjīchǔ.
 1	在	在	ADP	_	_	3	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -13704,6 +14699,7 @@
 18	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 996
+# parallel_id = hk/996
 # text = 現在出現了兩個問題。
 # translit = xiànzàichūxiànleliǎnggèwèntí.
 1	現在	現在	NOUN	_	_	2	obl:tmod	_	SpaceAfter=No|Translit=xiànzài|LTranslit=xiànzài
@@ -13715,6 +14711,7 @@
 7	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 997
+# parallel_id = hk/997
 # text = 第一，候選人的資格成疑。
 # translit = dìyī,houxuǎnréndezīgéchéngyí.
 1	第一	第一	ADJ	_	_	6	advmod	_	SpaceAfter=No|Translit=dìyī|LTranslit=dìyī
@@ -13726,6 +14723,7 @@
 7	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 998
+# parallel_id = hk/998
 # text = 剛才多位議員已說過這點，我不詳述。
 # translit = gāngcáiduōwèiyìyuányǐshuōguòzhèdiǎn,wǒbùxiángshù.
 1	剛才	剛才	ADV	_	_	6	advmod	_	SpaceAfter=No|Translit=gāngcái|LTranslit=gāngcái
@@ -13744,6 +14742,7 @@
 14	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 999
+# parallel_id = hk/999
 # text = 第二個問題是關於投票人的資格，《議事規則》訂明的上一項程序根本未完成。
 # translit = dì'èrgèwèntíshìguānyútóupiàoréndezīgé,«yìshìguīzé»dìngmíngdeshàngyīxiàngchéngxùgēnběnwèiwánchéng.
 1	第二	第二	ADJ	_	_	3	amod	_	SpaceAfter=No|Translit=dì'èr|LTranslit=dì'èr
@@ -13772,6 +14771,7 @@
 24	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 1000
+# parallel_id = hk/1000
 # text = 如何開始下一步選舉主席的會議？
 # translit = rúhékāishǐxiàyībùxuǎnjǔzhǔxídehuìyì?
 1	如何	如何	ADV	_	_	2	advmod	_	SpaceAfter=No|Translit=rúhé|LTranslit=rúhé
@@ -13786,6 +14786,7 @@
 10	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = 1001
+# parallel_id = hk/1001
 # text = 《議事規則》已清楚訂明由議員宣誓至選舉主席的程序。
 # translit = «yìshìguīzé»yǐqīngchudìngmíngyóuyìyuánxuānshìzhìxuǎnjǔzhǔxídechéngxù.
 1	《	《	PUNCT	_	_	3	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -13807,6 +14808,7 @@
 17	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 1002
+# parallel_id = hk/1002
 # text = 在第十二條（每屆任期的首次會議）已有明確規定。
 # translit = zàidìshí'èrtiáo(měijièrènqīdeshǒucìhuìyì)yǐyǒumíngquèguīdìng.
 1	在	在	ADP	_	_	3	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -13828,6 +14830,7 @@
 17	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 1003
+# parallel_id = hk/1003
 # text = 所以，主席，請你先看看《議事規則》，以決定各事項的先後次序。
 # translit = suǒyǐ,zhǔxí,qǐngnǐxiānkànkàn«yìshìguīzé»,yǐjuédìnggèshìxiàngdexiānhòucìxù.
 1	所以	所以	ADV	_	_	5	advmod	_	SpaceAfter=No|Translit=suǒyǐ|LTranslit=suǒyǐ
@@ -13853,6 +14856,7 @@
 21	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = 1004
+# parallel_id = hk/1004
 # text = 應該讓每位出席會議的議員作出宗教式或非宗教式宣誓後，再按照《議事規則》第四條進行選舉主席的程序。
 # translit = yīnggāiràngměiwèichūxíhuìyìdeyìyuánzuòchūzōngjiàoshìhuòfēizōngjiàoshìxuānshìhòu,zài'ànzhào«yìshìguīzé»dìsìtiáojìnxíngxuǎnjǔzhǔxídechéngxù.
 1	應該	應該	AUX	_	_	2	aux	_	SpaceAfter=No|Translit=yīnggāi|LTranslit=yīnggāi


### PR DESCRIPTION
update README metadata and add parallel IDs
     - add "Parallel: "hk" to indicate parallel data availability
add " parallel_id = hk/ test{n}/part{n} alt{n}" format to support automated parallel sentences identification, where n = any number (positive intergers, arabic numerals, starts with 1)